### PR TITLE
chore: mark generated files for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+docs/api/openapi.json linguist-generated=true
+app/types/api.ts linguist-generated=true
+lib/pico/generatedContent.ts linguist-generated=true
+next-env.d.ts linguist-generated=true


### PR DESCRIPTION
Task: Phase 4 PR 2, generated-file classification. Mark committed generated artifacts for GitHub linguist without changing generated contents.

Changed files:
- .gitattributes

LOC/files before:
- Tracked files: 1,653
- Tracked line count sanity check: 671,634

LOC/files after:
- Tracked files: 1,654
- Tracked line count sanity check: 671,638

Files deleted:
- None

Why safe:
- Adds linguist-generated=true markers only.
- Does not edit docs/api/openapi.json, app/types/api.ts, lib/pico/generatedContent.ts, or next-env.d.ts contents.
- No API, SDK, CLI, dashboard, tests, auth, evidence-loop, infra, or generated contract behavior changed.

Validation run:
- git check-attr linguist-generated -- docs/api/openapi.json app/types/api.ts lib/pico/generatedContent.ts next-env.d.ts
- git diff --cached --check
- PYTHON_BIN=./.venv/bin/python bash scripts/verify-generated-artifacts.sh

Rollback risk:
- Low. Reverting removes only GitHub linguist metadata.

Follow-up cuts:
- Tighten gitignore for remaining generated local outputs in a separate PR.
- Keep generated contract regeneration in the contract guardian lane when API changes are made.
