### PR TITLE
chore: tighten gitignore for generated outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ dist/
 build/
 out/
 public/_next/
-tsconfig.tsbuildinfo
+*.tsbuildinfo
 
 # Capacitor / mobile
 android/app/src/main/assets/
@@ -71,6 +71,7 @@ infrastructure/terraform/*.backup
 # Runtime / tooling workspace
 .autonomy/
 .minimax/
+.playwright-mcp/
 
 # Generated
 next-env.d.ts
@@ -123,7 +124,11 @@ pnpm-lock.yaml
 .worktrees/
 public/docs-search-index.json
 *.bak
+*.backup
 ALL_MUTX_PDFs_Extracted.txt
+
+# Local visual review captures
+/pico-*.png
 
 # GTM data — local only, never in repo
 docs/pico-gtm/


### PR DESCRIPTION
Task: Phase 4 PR 3, gitignore tightening. Ignore local generated/tooling outputs without deleting files or changing contracts.

Changed files:
- .gitignore

LOC/files before:
- Tracked files: 1,653
- Tracked line count sanity check: 671,634

LOC/files after:
- Tracked files: 1,653
- Tracked line count sanity check: 671,639

Files deleted:
- None

Why safe:
- Ignore-only change.
- New patterns match no tracked files: .playwright-mcp/**, root /pico-*.png visual-review captures, *.backup, and generic *.tsbuildinfo.
- Does not touch API, generated OpenAPI/types, SDK, CLI, auth, evidence-loop, migrations, billing, or infra.

Validation run:
- git ls-files '.playwright-mcp/**' 'pico-*.png' '*.backup' '*.tsbuildinfo' (no tracked matches)
- git check-ignore -v .playwright-mcp pico-final-1800.png tests/unit/middlewareRouting.test.ts.backup tsconfig.tsbuildinfo
- git diff --check
- ./.venv/bin/python -m pytest tests/test_demo_validate_script.py -q (3 passed)

Rollback risk:
- Low. Reverting only allows local generated outputs to reappear as untracked files.

Follow-up cuts:
- After cache cleanup merges, verify no tracked Playwright output remains.
- Next refactor PR should pick one stale preview surface only after route/reference proof.
