### PR TITLE
fix: pin FastAPI below included-router regression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # Core API
-fastapi>=0.115.0
+# FastAPI 0.137 introduced included-router wrappers that are not yet compatible
+# with our route inventory and OpenTelemetry FastAPI instrumentation.
+fastapi==0.135.3
 uvicorn[standard]==0.27.0
 starlette>=0.49.1
 pydantic==2.10.6

--- a/tests/test_python_dependency_contract.py
+++ b/tests/test_python_dependency_contract.py
@@ -9,11 +9,14 @@ def read_text(relative_path: str) -> str:
 
 
 def test_test_requirements_do_not_drift_from_runtime_core_pins() -> None:
+    runtime_requirements = read_text("requirements.txt")
     test_requirements = read_text("test-requirements.txt")
 
+    assert "fastapi==0.135.3" in runtime_requirements
+    assert "fastapi>=" not in runtime_requirements
     assert "-r requirements.txt" in test_requirements
     assert "passlib[bcrypt]" not in test_requirements
-    assert "httpx==0.26.0" in test_requirements
+    assert "httpx==0.28.1" in test_requirements
     assert "aiosqlite==0.20.0" in test_requirements
     assert "sqlalchemy==2.0.25" in test_requirements
 


### PR DESCRIPTION
## Summary
- pin FastAPI to the last validated 0.135.3 release
- prevent the 0.137 included-router wrapper from breaking route inventory and OpenTelemetry instrumentation
- refresh the stale httpx dependency-contract assertion

## Validation
- dependency compatibility script
- 10 focused dependency, app-factory, and agent-runtime tests
- Ruff check and format check
- git diff --check

@codex please review