### PR TITLE
refactor(api): consolidate event ingestion service

### DIFF
--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -1372,10 +1372,6 @@ export interface paths {
         /**
          * Ingest Event
          * @description Accept structured events from SDK adapters (LangChain, CrewAI, AutoGen).
-         *
-         *     When ``agent_id`` is provided the event is persisted as an ``AgentLog``
-         *     for audit trail; otherwise it is accepted and logged without persistent
-         *     storage.
          */
         post: operations["ingest_event_v1_events_post"];
         delete?: never;
@@ -1455,13 +1451,7 @@ export interface paths {
         put?: never;
         /**
          * Ingest Event
-         * @description Canonical event ingestion endpoint for SDK adapters.
-         *
-         *     Accepts structured events from LangChain, CrewAI, AutoGen, and future
-         *     adapter integrations.  When ``agent_id`` is provided the event is
-         *     persisted as an ``AgentLog`` for audit trail; otherwise it is accepted
-         *     and logged without persistent storage (a dedicated events table is
-         *     planned for Wave 2).
+         * @description Accept structured events from SDK adapters through the legacy alias.
          */
         post: operations["ingest_event_v1_ingest_events_post"];
         delete?: never;

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5457,7 +5457,7 @@
           "events"
         ],
         "summary": "Ingest Event",
-        "description": "Accept structured events from SDK adapters (LangChain, CrewAI, AutoGen).\n\nWhen ``agent_id`` is provided the event is persisted as an ``AgentLog``\nfor audit trail; otherwise it is accepted and logged without persistent\nstorage.",
+        "description": "Accept structured events from SDK adapters (LangChain, CrewAI, AutoGen).",
         "operationId": "ingest_event_v1_events_post",
         "parameters": [
           {
@@ -5765,7 +5765,7 @@
           "ingest"
         ],
         "summary": "Ingest Event",
-        "description": "Canonical event ingestion endpoint for SDK adapters.\n\nAccepts structured events from LangChain, CrewAI, AutoGen, and future\nadapter integrations.  When ``agent_id`` is provided the event is\npersisted as an ``AgentLog`` for audit trail; otherwise it is accepted\nand logged without persistent storage (a dedicated events table is\nplanned for Wave 2).",
+        "description": "Accept structured events from SDK adapters through the legacy alias.",
         "operationId": "ingest_event_v1_ingest_events_post",
         "parameters": [
           {

--- a/src/api/routes/events.py
+++ b/src/api/routes/events.py
@@ -2,88 +2,29 @@
 
 SDK adapters (LangChain, CrewAI, AutoGen) POST to ``/v1/events``.
 This module registers the route at the path the adapters already use,
-delegating to the same ingestion logic that lives on the ingest router
-at ``/v1/ingest/events``.
+delegating to the shared ingestion service.
 """
 
-from sqlalchemy import select
-import json
 import logging
-from typing import Optional
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.database import get_db
 from src.api.middleware.auth import get_current_user_or_api_key
-from src.api.models import Agent, AgentLog, User
+from src.api.models import User
 from src.api.models.schemas import IngestEvent
+from src.api.services.event_ingestion import process_ingest_event
 
 router = APIRouter(tags=["events"])
 logger = logging.getLogger(__name__)
-
-
-async def _events_auth(
-    authorization: Optional[str] = Header(None),
-    x_api_key: Optional[str] = Header(None, alias="X-API-Key"),
-    session: AsyncSession = Depends(get_db),
-    *,
-    request: Request,
-) -> User:
-    user = await get_current_user_or_api_key(
-        request=request,
-        authorization=authorization,
-        x_api_key=x_api_key,
-        session=session,
-    )
-    if not user:
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid authentication. Provide valid JWT Bearer token or X-API-Key header.",
-        )
-    return user
 
 
 @router.post("/events")
 async def ingest_event(
     event_data: IngestEvent,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(_events_auth),
+    current_user: User = Depends(get_current_user_or_api_key),
 ):
-    """Accept structured events from SDK adapters (LangChain, CrewAI, AutoGen).
-
-    When ``agent_id`` is provided the event is persisted as an ``AgentLog``
-    for audit trail; otherwise it is accepted and logged without persistent
-    storage.
-    """
-    resolved_agent_id = event_data.agent_id
-
-    if resolved_agent_id is not None:
-        result = await db.execute(select(Agent).where(Agent.id == resolved_agent_id))
-        agent = result.scalar_one_or_none()
-        if not agent:
-            raise HTTPException(status_code=404, detail="Agent not found")
-        if agent.user_id != current_user.id:
-            raise HTTPException(
-                status_code=403, detail="Not authorized to ingest events for this agent"
-            )
-
-        log = AgentLog(
-            agent_id=resolved_agent_id,
-            level="info",
-            message=f"Adapter event: {event_data.event_type}",
-            extra_data=json.dumps(event_data.payload, default=str),
-            meta_data={
-                "event_type": event_data.event_type,
-                "adapter_timestamp": event_data.timestamp,
-                "agent_id": str(resolved_agent_id),
-            },
-        )
-        db.add(log)
-        await db.commit()
-
-    logger.info(
-        f"Ingested event type={event_data.event_type} user={current_user.id}"
-        + (f" agent={resolved_agent_id}" if resolved_agent_id else " (no agent)")
-    )
-    return {"status": "accepted", "event_type": event_data.event_type}
+    """Accept structured events from SDK adapters (LangChain, CrewAI, AutoGen)."""
+    return await process_ingest_event(event_data, current_user, db)

--- a/src/api/routes/ingest.py
+++ b/src/api/routes/ingest.py
@@ -1,10 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException, Header, Request
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+import logging
 from datetime import datetime, timezone
 from typing import Optional
-import json
-import logging
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.database import get_db
 from src.api.models import (
@@ -23,6 +23,7 @@ from src.api.models.schemas import (
     MetricsReportRequest,
 )
 from src.api.middleware.auth import get_current_user_or_api_key
+from src.api.services.event_ingestion import process_ingest_event
 from src.api.services.webhook_service import (
     trigger_agent_status_event,
     trigger_deployment_event,
@@ -229,43 +230,5 @@ async def ingest_event(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_ingest_auth),
 ):
-    """Canonical event ingestion endpoint for SDK adapters.
-
-    Accepts structured events from LangChain, CrewAI, AutoGen, and future
-    adapter integrations.  When ``agent_id`` is provided the event is
-    persisted as an ``AgentLog`` for audit trail; otherwise it is accepted
-    and logged without persistent storage (a dedicated events table is
-    planned for Wave 2).
-    """
-    resolved_agent_id = event_data.agent_id
-
-    # If an agent_id is provided, verify ownership and persist
-    if resolved_agent_id is not None:
-        result = await db.execute(select(Agent).where(Agent.id == resolved_agent_id))
-        agent = result.scalar_one_or_none()
-        if not agent:
-            raise HTTPException(status_code=404, detail="Agent not found")
-        if agent.user_id != current_user.id:
-            raise HTTPException(
-                status_code=403, detail="Not authorized to ingest events for this agent"
-            )
-
-        log = AgentLog(
-            agent_id=resolved_agent_id,
-            level="info",
-            message=f"Adapter event: {event_data.event_type}",
-            extra_data=json.dumps(event_data.payload, default=str),
-            meta_data={
-                "event_type": event_data.event_type,
-                "adapter_timestamp": event_data.timestamp,
-                "agent_id": str(resolved_agent_id),
-            },
-        )
-        db.add(log)
-        await db.commit()
-
-    logger.info(
-        f"Ingested event type={event_data.event_type} user={current_user.id}"
-        + (f" agent={resolved_agent_id}" if resolved_agent_id else " (no agent)")
-    )
-    return {"status": "accepted", "event_type": event_data.event_type}
+    """Accept structured events from SDK adapters through the legacy alias."""
+    return await process_ingest_event(event_data, current_user, db)

--- a/src/api/services/event_ingestion.py
+++ b/src/api/services/event_ingestion.py
@@ -1,0 +1,66 @@
+"""Shared event ingestion logic for SDK adapter events.
+
+Used by both ``/v1/events`` and ``/v1/ingest/events`` route handlers so
+that the ingestion contract, ownership checks, and audit-log persistence
+stay in one place.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.models import Agent, AgentLog, User
+from src.api.models.schemas import IngestEvent
+
+logger = logging.getLogger(__name__)
+
+
+async def process_ingest_event(
+    event_data: IngestEvent,
+    current_user: User,
+    db: AsyncSession,
+) -> dict[str, str]:
+    """Validate, authorize, and persist an SDK adapter event.
+
+    Returns a JSON-serializable dict suitable as the route response.
+    """
+    resolved_agent_id = event_data.agent_id
+
+    # If an agent_id is provided, verify ownership and persist as AgentLog
+    if resolved_agent_id is not None:
+        result = await db.execute(select(Agent).where(Agent.id == resolved_agent_id))
+        agent = result.scalar_one_or_none()
+        if not agent:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        if agent.user_id != current_user.id:
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to ingest events for this agent",
+            )
+
+        log = AgentLog(
+            agent_id=resolved_agent_id,
+            level="info",
+            message=f"Adapter event: {event_data.event_type}",
+            extra_data=json.dumps(event_data.payload, default=str),
+            meta_data={
+                "event_type": event_data.event_type,
+                "adapter_timestamp": event_data.timestamp,
+                "agent_id": str(resolved_agent_id),
+            },
+        )
+        db.add(log)
+        await db.commit()
+
+    logger.info(
+        "Ingested event type=%s user=%s agent=%s",
+        event_data.event_type,
+        current_user.id,
+        resolved_agent_id,
+    )
+    return {"status": "accepted", "event_type": event_data.event_type}

--- a/tests/api/test_events_route.py
+++ b/tests/api/test_events_route.py
@@ -1,0 +1,236 @@
+"""Tests for POST /v1/events — canonical SDK event ingestion endpoint.
+
+Validates that the /v1/events route delegates correctly to the shared
+event ingestion service (src.api.services.event_ingestion).
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.models.models import Agent, AgentLog, AgentStatus, User
+
+
+class TestEventsRoute:
+    """Tests for /v1/events endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_events_requires_auth(self, client_no_auth: AsyncClient):
+        """POST /v1/events requires authentication."""
+        response = await client_no_auth.post(
+            "/v1/events",
+            json={"event_type": "agent_action"},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_events_minimal_payload(self, client: AsyncClient):
+        """Accept a minimal event with just event_type."""
+        response = await client.post(
+            "/v1/events",
+            json={"event_type": "agent_action"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "accepted"
+        assert data["event_type"] == "agent_action"
+
+    @pytest.mark.asyncio
+    async def test_events_with_payload(self, client: AsyncClient):
+        """Accept an event with adapter-specific payload."""
+        response = await client.post(
+            "/v1/events",
+            json={
+                "event_type": "crew_task_start",
+                "timestamp": "2026-04-20T09:00:00Z",
+                "payload": {
+                    "crew_name": "research-crew",
+                    "task_description": "Analyze documents",
+                },
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["event_type"] == "crew_task_start"
+
+    @pytest.mark.asyncio
+    async def test_events_langchain_shape(self, client: AsyncClient):
+        """Accept an event matching the LangChain adapter shape."""
+        response = await client.post(
+            "/v1/events",
+            json={
+                "event_type": "agent_action",
+                "timestamp": "2026-04-20T09:00:00Z",
+                "payload": {
+                    "agent_name": "researcher",
+                    "tool": "search",
+                    "tool_input": "MUTX governance",
+                    "run_id": str(uuid.uuid4()),
+                },
+            },
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_events_autogen_shape(self, client: AsyncClient):
+        """Accept an event matching the AutoGen adapter shape."""
+        response = await client.post(
+            "/v1/events",
+            json={
+                "event_type": "autogen_llm_call",
+                "timestamp": "2026-04-20T09:00:00Z",
+                "payload": {
+                    "agent_name": "assistant",
+                    "model": "gpt-4",
+                },
+            },
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_events_with_owned_agent(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        """Accept an event with agent_id for an owned agent."""
+        agent_id = uuid.uuid4()
+        agent = Agent(
+            id=agent_id,
+            user_id=test_user.id,
+            name="Test Agent",
+            status=AgentStatus.RUNNING.value,
+        )
+        db_session.add(agent)
+        await db_session.commit()
+
+        response = await client.post(
+            "/v1/events",
+            json={
+                "event_type": "agent_action",
+                "agent_id": str(agent_id),
+                "payload": {"tool": "search"},
+            },
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_events_agent_not_found(self, client: AsyncClient):
+        """Return 404 when agent_id references a non-existent agent."""
+        response = await client.post(
+            "/v1/events",
+            json={
+                "event_type": "agent_action",
+                "agent_id": str(uuid.uuid4()),
+            },
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_events_agent_wrong_owner(self, client: AsyncClient, db_session: AsyncSession):
+        """Return 403 when agent_id references an agent owned by another user."""
+        other_user = User(
+            id=uuid.uuid4(),
+            email="other-events@example.com",
+            password_hash="hash",
+            name="Other User",
+        )
+        db_session.add(other_user)
+        await db_session.commit()
+
+        agent_id = uuid.uuid4()
+        agent = Agent(
+            id=agent_id,
+            user_id=other_user.id,
+            name="Other Agent",
+            status=AgentStatus.RUNNING.value,
+        )
+        db_session.add(agent)
+        await db_session.commit()
+
+        response = await client.post(
+            "/v1/events",
+            json={
+                "event_type": "agent_action",
+                "agent_id": str(agent_id),
+            },
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_events_empty_event_type_rejected(self, client: AsyncClient):
+        """Reject events with an empty event_type."""
+        response = await client.post(
+            "/v1/events",
+            json={"event_type": ""},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_events_missing_event_type_rejected(self, client: AsyncClient):
+        """Reject events with no event_type field."""
+        response = await client.post(
+            "/v1/events",
+            json={"payload": {"some": "data"}},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_events_persists_agent_log(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        """Verify the event is stored as an AgentLog when agent_id is provided."""
+        agent_id = uuid.uuid4()
+        agent = Agent(
+            id=agent_id,
+            user_id=test_user.id,
+            name="Test Agent",
+            status=AgentStatus.RUNNING.value,
+        )
+        db_session.add(agent)
+        await db_session.commit()
+
+        response = await client.post(
+            "/v1/events",
+            json={
+                "event_type": "crew_task_end",
+                "agent_id": str(agent_id),
+                "timestamp": "2026-04-20T09:00:00Z",
+                "payload": {"crew_name": "test-crew"},
+            },
+        )
+        assert response.status_code == 200
+
+        logs = (
+            (
+                await db_session.execute(
+                    select(AgentLog)
+                    .where(
+                        AgentLog.agent_id == agent_id,
+                        AgentLog.message == "Adapter event: crew_task_end",
+                    )
+                    .order_by(AgentLog.timestamp.desc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(logs) >= 1
+        log = logs[0]
+        assert log.level == "info"
+        assert log.meta_data is not None
+        assert log.meta_data["event_type"] == "crew_task_end"
+        assert log.meta_data["adapter_timestamp"] == "2026-04-20T09:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_events_no_agent_id_accepted_no_log(self, client: AsyncClient):
+        """Events without agent_id are accepted but no AgentLog is created."""
+        response = await client.post(
+            "/v1/events",
+            json={
+                "event_type": "system.heartbeat",
+                "timestamp": "2026-04-20T10:00:00Z",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "accepted"


### PR DESCRIPTION
## Summary

- extracts event validation, ownership checks, persistence, and response formatting into one shared service
- routes both POST /v1/events and POST /v1/ingest/events through that service
- restores comprehensive coverage for the SDK-facing /v1/events contract while retaining the legacy-alias suite
- refreshes checked-in OpenAPI and TypeScript contract artifacts for the route descriptions

## Why

The two public event-ingestion aliases had copied handler logic. That duplication could drift in authorization, persistence, or response behavior. PR #3796 began the extraction but no longer applied cleanly to current main and did not wire the newer /v1/ingest/events implementation into the shared path.

## Impact

SDK adapters keep using /v1/events unchanged. Existing /v1/ingest/events clients also retain their contract. Both now share one implementation for ownership enforcement and AgentLog persistence.

## Validation

- python -m pytest tests/api/test_events_route.py tests/api/test_ingest_events.py -q — 23 passed
- python -m pytest tests/api --maxfail=1 -q — 798 passed
- npm test -- --runInBand — 435 passed
- npm run lint — passed
- bash scripts/verify-generated-artifacts.sh — passed
- python -m ruff check src/api cli sdk src/security — passed
- python -m ruff format --check src/api cli sdk src/security — 256 files already formatted
- python -m black --check src/api/routes/events.py src/api/routes/ingest.py src/api/services/event_ingestion.py tests/api/test_events_route.py — passed
- python -m compileall -q src/api cli sdk/mutx src/security — passed

Supersedes #3796.