### PR TITLE
feat(security): govern runtime tool execution

### DIFF
--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -3746,6 +3746,7 @@ export interface paths {
          *         current_user: The authenticated user.
          *         agent_id: Optional agent ID filter.
          *         session_id: Optional session ID filter.
+         *         run_id: Optional run ID filter.
          *         time_range_start: Optional start time filter.
          *         time_range_end: Optional end time filter.
          *         event_type: Optional event type filter.
@@ -3756,6 +3757,26 @@ export interface paths {
          *         AuditEventsResponse containing list of matching events.
          */
         get: operations["query_audit_events_v1_audit_events_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/audit/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export Audit Evidence
+         * @description Export a verified SHA-256 evidence chain for one run or session.
+         */
+        get: operations["export_audit_evidence_v1_audit_export_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5029,8 +5050,12 @@ export interface components {
             agent_id: string;
             /** Session Id */
             session_id: string;
+            /** Run Id */
+            run_id?: string | null;
             /** Span Id */
             span_id?: string | null;
+            /** Parent Span Id */
+            parent_span_id?: string | null;
             /** Event Type */
             event_type: string;
             /** Payload */
@@ -5042,6 +5067,37 @@ export interface components {
             timestamp: string;
             /** Trace Id */
             trace_id?: string | null;
+            /**
+             * Actor Type
+             * @default agent
+             */
+            actor_type: string;
+            /** Actor Id */
+            actor_id?: string | null;
+            /** Actor Display */
+            actor_display?: string | null;
+            /** Policy Decision Id */
+            policy_decision_id?: string | null;
+            /** Policy Refs */
+            policy_refs?: string[];
+            /** Approval Id */
+            approval_id?: string | null;
+            /** Cost Record */
+            cost_record?: Record<string, never> | null;
+            /**
+             * Redaction Status
+             * @default none
+             */
+            redaction_status: string;
+            /**
+             * Schema Version
+             * @default 1.0
+             */
+            schema_version: string;
+            /** Previous Hash */
+            previous_hash?: string | null;
+            /** Integrity Hash */
+            integrity_hash?: string | null;
         };
         /**
          * AuditEventType
@@ -5058,6 +5114,30 @@ export interface components {
             events: components["schemas"]["AuditEventResponse"][];
             /** Total */
             total?: number | null;
+        };
+        /**
+         * AuditEvidenceExportResponse
+         * @description Verified governed-operation evidence chain export.
+         */
+        AuditEvidenceExportResponse: {
+            /** Schema Version */
+            schema_version: string;
+            /** Algorithm */
+            algorithm: string;
+            /** Run Id */
+            run_id?: string | null;
+            /** Session Id */
+            session_id?: string | null;
+            /** Event Count */
+            event_count: number;
+            /** Chain Root */
+            chain_root?: string | null;
+            /** Verified */
+            verified: boolean;
+            /** Errors */
+            errors: string[];
+            /** Events */
+            events: components["schemas"]["AuditEventResponse"][];
         };
         /** BackendHealthResponse */
         BackendHealthResponse: {
@@ -17070,6 +17150,8 @@ export interface operations {
                 agent_id?: string | null;
                 /** @description Filter by session ID */
                 session_id?: string | null;
+                /** @description Filter by run ID */
+                run_id?: string | null;
                 /** @description Filter events after this timestamp (ISO 8601 format) */
                 time_range_start?: string | null;
                 /** @description Filter events before this timestamp (ISO 8601 format) */
@@ -17096,6 +17178,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuditEventsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_audit_evidence_v1_audit_export_get: {
+        parameters: {
+            query?: {
+                /** @description Run ID to export */
+                run_id?: string | null;
+                /** @description Session ID to export */
+                session_id?: string | null;
+            };
+            header?: {
+                Authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuditEvidenceExportResponse"];
                 };
             };
             /** @description Validation Error */

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -14443,7 +14443,7 @@
           "audit"
         ],
         "summary": "Query Audit Events",
-        "description": "Query audit events with filters.\n\nRequires authentication. Results are ordered by timestamp descending.\n\nArgs:\n    current_user: The authenticated user.\n    agent_id: Optional agent ID filter.\n    session_id: Optional session ID filter.\n    time_range_start: Optional start time filter.\n    time_range_end: Optional end time filter.\n    event_type: Optional event type filter.\n    limit: Maximum number of events to return (1-1000, default 100).\n    skip: Number of events to skip for pagination.\n\nReturns:\n    AuditEventsResponse containing list of matching events.",
+        "description": "Query audit events with filters.\n\nRequires authentication. Results are ordered by timestamp descending.\n\nArgs:\n    current_user: The authenticated user.\n    agent_id: Optional agent ID filter.\n    session_id: Optional session ID filter.\n    run_id: Optional run ID filter.\n    time_range_start: Optional start time filter.\n    time_range_end: Optional end time filter.\n    event_type: Optional event type filter.\n    limit: Maximum number of events to return (1-1000, default 100).\n    skip: Number of events to skip for pagination.\n\nReturns:\n    AuditEventsResponse containing list of matching events.",
         "operationId": "query_audit_events_v1_audit_events_get",
         "parameters": [
           {
@@ -14481,6 +14481,24 @@
               "title": "Session Id"
             },
             "description": "Filter by session ID"
+          },
+          {
+            "name": "run_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by run ID",
+              "title": "Run Id"
+            },
+            "description": "Filter by run ID"
           },
           {
             "name": "time_range_start",
@@ -14589,6 +14607,92 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AuditEventsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/audit/export": {
+      "get": {
+        "tags": [
+          "audit"
+        ],
+        "summary": "Export Audit Evidence",
+        "description": "Export a verified SHA-256 evidence chain for one run or session.",
+        "operationId": "export_audit_evidence_v1_audit_export_get",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Run ID to export",
+              "title": "Run Id"
+            },
+            "description": "Run ID to export"
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Session ID to export",
+              "title": "Session Id"
+            },
+            "description": "Session ID to export"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditEvidenceExportResponse"
                 }
               }
             }
@@ -17510,6 +17614,17 @@
             "type": "string",
             "title": "Session Id"
           },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Id"
+          },
           "span_id": {
             "anyOf": [
               {
@@ -17520,6 +17635,17 @@
               }
             ],
             "title": "Span Id"
+          },
+          "parent_span_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Span Id"
           },
           "event_type": {
             "type": "string",
@@ -17544,6 +17670,105 @@
               }
             ],
             "title": "Trace Id"
+          },
+          "actor_type": {
+            "type": "string",
+            "title": "Actor Type",
+            "default": "agent"
+          },
+          "actor_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor Id"
+          },
+          "actor_display": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor Display"
+          },
+          "policy_decision_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Policy Decision Id"
+          },
+          "policy_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Policy Refs"
+          },
+          "approval_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approval Id"
+          },
+          "cost_record": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Record"
+          },
+          "redaction_status": {
+            "type": "string",
+            "title": "Redaction Status",
+            "default": "none"
+          },
+          "schema_version": {
+            "type": "string",
+            "title": "Schema Version",
+            "default": "1.0"
+          },
+          "previous_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Previous Hash"
+          },
+          "integrity_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Integrity Hash"
           }
         },
         "type": "object",
@@ -17598,6 +17823,84 @@
         ],
         "title": "AuditEventsResponse",
         "description": "Response model for a list of audit events."
+      },
+      "AuditEvidenceExportResponse": {
+        "properties": {
+          "schema_version": {
+            "type": "string",
+            "title": "Schema Version"
+          },
+          "algorithm": {
+            "type": "string",
+            "title": "Algorithm"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Id"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "event_count": {
+            "type": "integer",
+            "title": "Event Count"
+          },
+          "chain_root": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chain Root"
+          },
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
+          "errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Errors"
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/AuditEventResponse"
+            },
+            "type": "array",
+            "title": "Events"
+          }
+        },
+        "type": "object",
+        "required": [
+          "schema_version",
+          "algorithm",
+          "event_count",
+          "verified",
+          "errors",
+          "events"
+        ],
+        "title": "AuditEvidenceExportResponse",
+        "description": "Verified governed-operation evidence chain export."
       },
       "BackendHealthResponse": {
         "properties": {

--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -157,6 +157,26 @@ Workflow automation with visual builder integration.
 
 ## Tool Execution
 
+Every LangChain tool registered through `AgentRuntime` is mediated before its
+handler can run. The runtime normalizes the call with `ActionMediator`, evaluates
+the active `PolicyEngine` policy, and then applies the decision:
+
+* `ALLOW` and `MODIFY` execute the original handler (with modified arguments when supplied).
+* `DENY` blocks the handler and emits an action receipt.
+* `DEFER` blocks the handler and opens an `ApprovalService` request.
+
+The default runtime policy allows the low-risk built-ins (`get_time`,
+`calculator`, and `search_documents`) and denies custom tools until a policy is
+configured. Security REST routes and agent execution share the same governance
+composition root, so receipts and approval requests remain visible through the
+existing `/v1/security/*` endpoints.
+
+Each decision also appends a RunEvent v1-compatible audit record with the run,
+actor, policy decision, approval, cost/redaction metadata, and a SHA-256 link to
+the prior event in that run. Administrators can retrieve and verify a chain with
+`GET /v1/audit/export?run_id=<run-id>` (or export all run chains in a session via
+`session_id`).
+
 ### Tool Handler Architecture
 
 ```

--- a/examples/langchain_agent.py
+++ b/examples/langchain_agent.py
@@ -9,6 +9,9 @@ Run with:
     python examples/langchain_agent.py
 """
 
+import ast
+import operator
+
 # LangChain imports
 from langchain.agents import AgentExecutor, create_react_agent
 from langchain_core.tools import tool
@@ -16,6 +19,47 @@ from langchain_openai import ChatOpenAI
 
 # MUTX adapter imports
 from mutx.adapters.langchain import MutxAgentKit, MutxLangChainCallbackHandler
+
+
+_SAFE_BINARY_OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+_SAFE_UNARY_OPERATORS = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+_MAX_EXPRESSION_LENGTH = 200
+_MAX_POWER_EXPONENT = 100
+_MAX_RESULT_MAGNITUDE = 10**18
+
+
+def _evaluate_arithmetic(node: ast.AST) -> int | float:
+    """Evaluate a bounded arithmetic syntax tree without executing code."""
+    if isinstance(node, ast.Expression):
+        return _evaluate_arithmetic(node.body)
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
+            raise ValueError("Only numeric constants are allowed")
+        result = node.value
+    elif isinstance(node, ast.UnaryOp) and type(node.op) in _SAFE_UNARY_OPERATORS:
+        result = _SAFE_UNARY_OPERATORS[type(node.op)](_evaluate_arithmetic(node.operand))
+    elif isinstance(node, ast.BinOp) and type(node.op) in _SAFE_BINARY_OPERATORS:
+        left = _evaluate_arithmetic(node.left)
+        right = _evaluate_arithmetic(node.right)
+        if type(node.op) is ast.Pow and abs(right) > _MAX_POWER_EXPONENT:
+            raise ValueError("Power exponent is too large")
+        result = _SAFE_BINARY_OPERATORS[type(node.op)](left, right)
+    else:
+        raise ValueError("Unsupported expression")
+
+    if isinstance(result, bool) or not isinstance(result, (int, float)):
+        raise ValueError("Only real numeric results are allowed")
+    if abs(result) > _MAX_RESULT_MAGNITUDE:
+        raise ValueError("Result is too large")
+    return result
 
 
 # Define some simple tools for the agent to use
@@ -48,11 +92,15 @@ def calculator(expression: str) -> str:
         The result of the evaluation.
     """
     try:
-        # Security note: eval can be dangerous, this is for demonstration only
-        result = eval(expression, {"__builtins__": {}}, {})
+        normalized_expression = expression.strip()
+        if not normalized_expression:
+            raise ValueError("Expression is empty")
+        if len(normalized_expression) > _MAX_EXPRESSION_LENGTH:
+            raise ValueError("Expression is too long")
+        result = _evaluate_arithmetic(ast.parse(normalized_expression, mode="eval"))
         return str(result)
-    except Exception as e:
-        return f"Error: {e}"
+    except (ArithmeticError, SyntaxError, TypeError, ValueError) as exc:
+        return f"Error: {exc}"
 
 
 def main():
@@ -152,9 +200,7 @@ Answer the user's question using these tools when appropriate.
 
     # This should be blocked by the guardrail (contains "sensitive" keyword)
     try:
-        result = kit_with_guardrails.arun(
-            "Tell me about sensitive information in the database"
-        )
+        result = kit_with_guardrails.arun("Tell me about sensitive information in the database")
         print(f"\nResult: {result}\n")
     except Exception as e:
         print(f"\nGuardrail blocked the request: {e}\n")

--- a/src/api/integrations/langchain_agent.py
+++ b/src/api/integrations/langchain_agent.py
@@ -22,6 +22,7 @@ from langchain.agents import (
 from langchain.memory import ConversationBufferMemory
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 
+from .tool_names import RUNTIME_BUILTIN_TOOL_NAMES
 from .vector_store import VectorStoreRegistry
 
 logger = logging.getLogger(__name__)
@@ -149,6 +150,7 @@ class AgentConfig:
     memory_type: str = "buffer"
     max_iterations: int = 10
     verbose: bool = True
+    tool_executor: Optional[Callable[[str, str, Dict[str, Any], Callable], Any]] = None
 
 
 @dataclass
@@ -245,7 +247,11 @@ class ToolFactory:
     def _create_tool_from_definition(tool_def: ToolDefinition) -> BaseTool:
         from langchain_core.tools import tool
 
-        @tool(name=tool_def.name, args_schema=tool_def.parameters)
+        @tool(
+            tool_def.name,
+            args_schema=tool_def.parameters,
+            description=tool_def.description,
+        )
         def wrapper_func(**kwargs):
             return tool_def.function(kwargs)
 
@@ -339,6 +345,13 @@ class LangChainAgent:
         self.agent_executor = None
 
     def _initialize_tools(self) -> List[BaseTool]:
+        reserved_custom_names = sorted(
+            {definition.name for definition in self.config.tools} & set(RUNTIME_BUILTIN_TOOL_NAMES)
+        )
+        if reserved_custom_names:
+            names = ", ".join(reserved_custom_names)
+            raise ValueError(f"Custom tool names are reserved by the runtime: {names}")
+
         tool_definitions = list(self.config.tools)
         vector_store_name = self.config.vector_store_name
 
@@ -369,6 +382,27 @@ class LangChainAgent:
                 ),
             ]
         )
+
+        if self.config.tool_executor:
+            governed_definitions = []
+            for definition in tool_definitions:
+                original_handler = definition.function
+                governed_definitions.append(
+                    ToolDefinition(
+                        name=definition.name,
+                        description=definition.description,
+                        parameters=definition.parameters,
+                        function=lambda kwargs, name=definition.name, handler=original_handler: (
+                            self.config.tool_executor(
+                                self.agent_id,
+                                name,
+                                kwargs,
+                                handler,
+                            )
+                        ),
+                    )
+                )
+            tool_definitions = governed_definitions
 
         return ToolFactory.create_tools(tool_definitions)
 

--- a/src/api/integrations/tool_names.py
+++ b/src/api/integrations/tool_names.py
@@ -1,0 +1,3 @@
+"""Dependency-light names reserved for trusted runtime-provided tools."""
+
+RUNTIME_BUILTIN_TOOL_NAMES = ("get_time", "calculator", "search_documents")

--- a/src/api/routes/audit.py
+++ b/src/api/routes/audit.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.api.dependencies import get_current_user, require_roles, SSOTokenUser
 from src.api.services.audit_log import (
@@ -33,11 +33,24 @@ class AuditEventResponse(BaseModel):
     event_id: str
     agent_id: str
     session_id: str
+    run_id: str | None = None
     span_id: str | None = None
+    parent_span_id: str | None = None
     event_type: str
     payload: dict
     timestamp: datetime
     trace_id: str | None = None
+    actor_type: str = "agent"
+    actor_id: str | None = None
+    actor_display: str | None = None
+    policy_decision_id: str | None = None
+    policy_refs: list[str] = Field(default_factory=list)
+    approval_id: str | None = None
+    cost_record: dict[str, object] | None = None
+    redaction_status: str = "none"
+    schema_version: str = "1.0"
+    previous_hash: str | None = None
+    integrity_hash: str | None = None
 
     @classmethod
     def from_audit_event(cls, event: AuditEvent) -> "AuditEventResponse":
@@ -46,11 +59,24 @@ class AuditEventResponse(BaseModel):
             event_id=str(event.event_id),
             agent_id=event.agent_id,
             session_id=event.session_id,
+            run_id=event.run_id,
             span_id=event.span_id,
+            parent_span_id=event.parent_span_id,
             event_type=event.event_type.value,
             payload=event.payload,
             timestamp=event.timestamp,
             trace_id=event.trace_id,
+            actor_type=event.actor_type,
+            actor_id=event.actor_id,
+            actor_display=event.actor_display,
+            policy_decision_id=event.policy_decision_id,
+            policy_refs=event.policy_refs,
+            approval_id=event.approval_id,
+            cost_record=event.cost_record,
+            redaction_status=event.redaction_status,
+            schema_version=event.schema_version,
+            previous_hash=event.previous_hash,
+            integrity_hash=event.integrity_hash,
         )
 
 
@@ -59,6 +85,20 @@ class AuditEventsResponse(BaseModel):
 
     events: list[AuditEventResponse]
     total: int | None = None
+
+
+class AuditEvidenceExportResponse(BaseModel):
+    """Verified governed-operation evidence chain export."""
+
+    schema_version: str
+    algorithm: str
+    run_id: str | None = None
+    session_id: str | None = None
+    event_count: int
+    chain_root: str | None = None
+    verified: bool
+    errors: list[str]
+    events: list[AuditEventResponse]
 
 
 @router.get(
@@ -70,6 +110,7 @@ async def query_audit_events(
     current_user: Annotated[SSOTokenUser, Depends(get_current_user)],
     agent_id: Annotated[str | None, Query(description="Filter by agent ID")] = None,
     session_id: Annotated[str | None, Query(description="Filter by session ID")] = None,
+    run_id: Annotated[str | None, Query(description="Filter by run ID")] = None,
     time_range_start: Annotated[
         datetime | None,
         Query(
@@ -97,6 +138,7 @@ async def query_audit_events(
         current_user: The authenticated user.
         agent_id: Optional agent ID filter.
         session_id: Optional session ID filter.
+        run_id: Optional run ID filter.
         time_range_start: Optional start time filter.
         time_range_end: Optional end time filter.
         event_type: Optional event type filter.
@@ -109,6 +151,7 @@ async def query_audit_events(
     filters = AuditQuery(
         agent_id=agent_id,
         session_id=session_id,
+        run_id=run_id,
         time_range_start=time_range_start,
         time_range_end=time_range_end,
         event_type=event_type,
@@ -127,6 +170,33 @@ async def query_audit_events(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to query audit events: {str(e)}",
         )
+
+
+@router.get(
+    "/export",
+    response_model=AuditEvidenceExportResponse,
+    dependencies=[Depends(require_roles("ADMIN", "AUDIT_ADMIN"))],
+)
+async def export_audit_evidence(
+    current_user: Annotated[SSOTokenUser, Depends(get_current_user)],
+    run_id: Annotated[str | None, Query(description="Run ID to export")] = None,
+    session_id: Annotated[str | None, Query(description="Session ID to export")] = None,
+) -> AuditEvidenceExportResponse:
+    """Export a verified SHA-256 evidence chain for one run or session."""
+    try:
+        audit_log = await get_audit_log()
+        export = await audit_log.export_evidence(run_id=run_id, session_id=session_id)
+        return AuditEvidenceExportResponse(**export)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to export audit evidence: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to export audit evidence",
+        ) from exc
 
 
 @router.get(

--- a/src/api/routes/security.py
+++ b/src/api/routes/security.py
@@ -28,13 +28,8 @@ from pydantic import BaseModel, Field
 
 from src.api.middleware.auth import get_current_user
 from src.api.models import User
+from src.api.services.governance_runtime import get_governance_runtime
 from src.security import (
-    ActionMediator,
-    ContextAccumulator,
-    PolicyEngine,
-    ApprovalService,
-    ReceiptGenerator,
-    TelemetryExporter,
     AARMComplianceChecker,
     NormalizedAction,
 )
@@ -43,12 +38,13 @@ from src.security.telemetry import TelemetryEventType
 router = APIRouter(prefix="/security", tags=["security"])
 
 
-_mediator = ActionMediator()
-_context_accumulator = ContextAccumulator()
-_policy_engine = PolicyEngine()
-_approval_service = ApprovalService()
-_receipt_generator = ReceiptGenerator()
-_telemetry_exporter = TelemetryExporter()
+_governance = get_governance_runtime()
+_mediator = _governance.mediator
+_context_accumulator = _governance.context_accumulator
+_policy_engine = _governance.policy_engine
+_approval_service = _governance.approval_service
+_receipt_generator = _governance.receipt_generator
+_telemetry_exporter = _governance.telemetry_exporter
 
 
 class ActionEvaluateRequest(BaseModel):

--- a/src/api/services/agent_runtime.py
+++ b/src/api/services/agent_runtime.py
@@ -1,5 +1,6 @@
 import os
 import asyncio
+from contextvars import ContextVar, copy_context
 import logging
 import uuid
 from typing import Optional, List, Dict, Any, AsyncIterator, Callable
@@ -7,6 +8,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from datetime import datetime, timezone
 from contextlib import asynccontextmanager
+
+from src.api.services.governance_runtime import GovernanceRuntime, get_governance_runtime
 
 from ..integrations.langchain_agent import (
     LangChainAgent,
@@ -69,44 +72,184 @@ class RuntimeState:
 
 
 class ToolExecutionHandler:
-    def __init__(self):
+    def __init__(self, governance: GovernanceRuntime):
         self._handlers: Dict[str, Callable] = {}
+        self._governance = governance
 
     def register_handler(self, tool_name: str, handler: Callable):
+        if tool_name in self._governance.SAFE_BUILTIN_TOOLS:
+            raise ValueError(f"Tool name is reserved for a runtime built-in: {tool_name}")
+        self._register_handler(tool_name, handler)
+
+    def _register_builtin_handler(self, tool_name: str, handler: Callable) -> None:
+        if tool_name not in self._governance.SAFE_BUILTIN_TOOLS:
+            raise ValueError(f"Tool name is not a runtime built-in: {tool_name}")
+        self._register_handler(tool_name, handler)
+
+    def _register_handler(self, tool_name: str, handler: Callable) -> None:
         self._handlers[tool_name] = handler
         logger.info(f"Registered handler for tool: {tool_name}")
 
     def get_handler(self, tool_name: str) -> Optional[Callable]:
         return self._handlers.get(tool_name)
 
-    async def execute_tool(self, tool_name: str, parameters: Dict[str, Any]) -> Any:
-        handler = self.get_handler(tool_name)
+    async def execute_tool(
+        self,
+        tool_name: str,
+        parameters: Dict[str, Any],
+        *,
+        agent_id: str = "runtime-agent",
+        session_id: str | None = None,
+        run_id: str | None = None,
+        user_id: str = "",
+        actor_type: str = "agent",
+        actor_id: str | None = None,
+        actor_display: str | None = None,
+        handler_override: Callable | None = None,
+    ) -> Any:
+        resolved_run_id = run_id or str(uuid.uuid4())
+        resolved_session_id = session_id or resolved_run_id
+        evaluation = self._governance.authorize(
+            tool_name=tool_name,
+            tool_args=parameters,
+            agent_id=agent_id,
+            session_id=resolved_session_id,
+            run_id=resolved_run_id,
+            user_id=user_id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            actor_display=actor_display,
+        )
+
+        if evaluation.decision.is_denied:
+            receipt, audit_event = await self._governance.record_outcome(
+                evaluation,
+                outcome="blocked",
+                outcome_detail=evaluation.decision.reason,
+            )
+            return {
+                "error": "Tool execution denied by policy",
+                "decision": evaluation.decision.decision.value,
+                "reason": evaluation.decision.reason,
+                "receipt_id": receipt.receipt_id,
+                "integrity_hash": audit_event.integrity_hash,
+            }
+
+        if evaluation.decision.is_deferred:
+            receipt, audit_event = await self._governance.record_outcome(
+                evaluation,
+                outcome="approval_required",
+                outcome_detail=evaluation.decision.reason,
+            )
+            return {
+                "error": "Tool execution requires approval",
+                "decision": evaluation.decision.decision.value,
+                "reason": evaluation.decision.reason,
+                "approval_id": evaluation.approval.id if evaluation.approval else None,
+                "receipt_id": receipt.receipt_id,
+                "integrity_hash": audit_event.integrity_hash,
+            }
+
+        handler = handler_override or self.get_handler(tool_name)
         if not handler:
             logger.warning(f"No handler registered for tool: {tool_name}")
-            return {"error": f"Tool {tool_name} not found"}
+            error = f"Tool {tool_name} not found"
+            receipt, audit_event = await self._governance.record_outcome(
+                evaluation,
+                outcome="error",
+                outcome_detail=error,
+                error=error,
+            )
+            return {
+                "error": error,
+                "receipt_id": receipt.receipt_id,
+                "integrity_hash": audit_event.integrity_hash,
+            }
 
         try:
+            authorization_receipt, _ = await self._governance.record_authorization(evaluation)
+        except Exception:
+            logger.exception(
+                "Tool execution blocked because authorization evidence could not be persisted: %s",
+                tool_name,
+            )
+            return {
+                "error": "Tool execution blocked because authorization evidence could not be persisted",
+                "decision": evaluation.decision.decision.value,
+                "reason": evaluation.decision.reason,
+            }
+
+        modification_envelope = evaluation.decision.modifications or {}
+        effective_parameters = modification_envelope.get("modified_args", parameters)
+        try:
             if asyncio.iscoroutinefunction(handler):
-                return await handler(parameters)
-            return handler(parameters)
+                result = await handler(effective_parameters)
+            else:
+                result = handler(effective_parameters)
         except Exception as e:
             logger.error(f"Tool execution error for {tool_name}: {str(e)}")
+            try:
+                await self._governance.record_execution_result(
+                    evaluation,
+                    authorization_receipt=authorization_receipt,
+                    outcome="error",
+                    error=str(e),
+                )
+            except Exception:
+                logger.exception("Failed to persist tool execution failure evidence: %s", tool_name)
             return {"error": str(e)}
+
+        try:
+            await self._governance.record_execution_result(
+                evaluation,
+                authorization_receipt=authorization_receipt,
+                outcome="executed",
+                output_preview=str(result)[:500],
+            )
+        except Exception:
+            logger.exception(
+                "Tool executed but outcome evidence could not be persisted: %s", tool_name
+            )
+            return {
+                "error": "Tool executed but outcome evidence could not be persisted",
+                "result": result,
+                "receipt_id": authorization_receipt.receipt_id,
+            }
+        return result
 
 
 class AgentRuntime:
-    def __init__(self, config: RuntimeConfig):
+    def __init__(
+        self,
+        config: RuntimeConfig,
+        governance: GovernanceRuntime | None = None,
+    ):
         self.config = config
         self.runtime_id = str(uuid.uuid4())
         self.state = RuntimeState(
             runtime_id=self.runtime_id,
             status=RuntimeStatus.STOPPED,
         )
-        self.tool_handler = ToolExecutionHandler()
+        self.governance = governance or get_governance_runtime()
+        self.tool_handler = ToolExecutionHandler(self.governance)
         self._execution_callbacks: Dict[str, Callable] = {}
         self._running_tasks: Dict[str, asyncio.Task] = {}
+        self._execution_scope: ContextVar[tuple[str, str] | None] = ContextVar(
+            f"mutx_runtime_execution_{self.runtime_id}", default=None
+        )
+        self._event_loop: asyncio.AbstractEventLoop | None = None
+
+    def _bind_event_loop(self) -> asyncio.AbstractEventLoop:
+        """Bind governed operations to one owning loop for shared async state."""
+        event_loop = asyncio.get_running_loop()
+        if self._event_loop is not None and self._event_loop is not event_loop:
+            if self._event_loop.is_running():
+                raise RuntimeError("AgentRuntime is already bound to another event loop")
+        self._event_loop = event_loop
+        return event_loop
 
     async def start(self):
+        self._bind_event_loop()
         if self.state.status == RuntimeStatus.RUNNING:
             logger.warning(f"Runtime {self.runtime_id} already running")
             return
@@ -151,9 +294,11 @@ class AgentRuntime:
             logger.error(f"Failed to initialize vector store: {str(e)}")
 
     def _register_default_tool_handlers(self):
-        self.tool_handler.register_handler("search_documents", self._handle_search_documents)
-        self.tool_handler.register_handler("get_time", self._handle_get_time)
-        self.tool_handler.register_handler("calculator", self._handle_calculator)
+        self.tool_handler._register_builtin_handler(
+            "search_documents", self._handle_search_documents
+        )
+        self.tool_handler._register_builtin_handler("get_time", self._handle_get_time)
+        self.tool_handler._register_builtin_handler("calculator", self._handle_calculator)
 
     async def _handle_search_documents(self, params: Dict[str, Any]) -> str:
         store_name = params.get("store_name", "default")
@@ -200,6 +345,7 @@ class AgentRuntime:
             system_prompt=system_prompt,
             tools=tools or [],
             vector_store_name=vector_store_name,
+            tool_executor=self._execute_langchain_tool,
             **kwargs,
         )
         agent = AgentRegistry.create_agent(config)
@@ -207,12 +353,51 @@ class AgentRuntime:
         logger.info(f"Created agent {agent.agent_id} in runtime {self.runtime_id}")
         return agent
 
+    def _execute_langchain_tool(
+        self,
+        agent_id: str,
+        tool_name: str,
+        parameters: Dict[str, Any],
+        handler: Callable,
+    ) -> Any:
+        """Bridge synchronous LangChain tools through async governance enforcement."""
+        scope = self._execution_scope.get()
+        run_id, session_id = scope or (str(uuid.uuid4()), str(uuid.uuid4()))
+
+        async def execute() -> Any:
+            return await self.tool_handler.execute_tool(
+                tool_name,
+                parameters,
+                agent_id=agent_id,
+                session_id=session_id,
+                run_id=run_id,
+                handler_override=handler,
+            )
+
+        owner_loop = self._event_loop
+        if owner_loop is None or not owner_loop.is_running():
+            return asyncio.run(execute())
+
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        if current_loop is owner_loop:
+            raise RuntimeError(
+                "Synchronous governed tool calls cannot block the runtime event loop"
+            )
+
+        worker_context = copy_context()
+        future = worker_context.run(asyncio.run_coroutine_threadsafe, execute(), owner_loop)
+        return future.result()
+
     async def execute_agent(
         self,
         agent_id: str,
         input_text: str,
         timeout: Optional[int] = None,
     ) -> ExecutionContext:
+        self._bind_event_loop()
         execution_id = str(uuid.uuid4())
         context = ExecutionContext(
             execution_id=execution_id,
@@ -229,6 +414,7 @@ class AgentRuntime:
             return context
 
         timeout = timeout or self.config.default_timeout
+        scope_token = self._execution_scope.set((execution_id, execution_id))
 
         try:
             result = await asyncio.wait_for(
@@ -258,6 +444,8 @@ class AgentRuntime:
             context.completed_at = datetime.now(timezone.utc)
             self.state.failed_executions += 1
             logger.error(f"Execution {execution_id} error: {str(e)}")
+        finally:
+            self._execution_scope.reset(scope_token)
 
         if self._execution_callbacks.get(execution_id):
             callback = self._execution_callbacks.pop(execution_id)
@@ -270,13 +458,27 @@ class AgentRuntime:
         agent_id: str,
         input_text: str,
     ) -> AsyncIterator[str]:
+        self._bind_event_loop()
         agent = AgentRegistry.get_agent(agent_id)
         if not agent:
             yield f"Error: Agent {agent_id} not found"
             return
 
+        execution_id = str(uuid.uuid4())
+        scope_token = self._execution_scope.set((execution_id, execution_id))
         try:
-            for chunk in agent.stream_run(input_text):
+            stream = iter(agent.stream_run(input_text))
+
+            def next_chunk() -> tuple[bool, Any]:
+                try:
+                    return True, next(stream)
+                except StopIteration:
+                    return False, None
+
+            while True:
+                has_chunk, chunk = await asyncio.to_thread(next_chunk)
+                if not has_chunk:
+                    break
                 if isinstance(chunk, str):
                     yield chunk
                 else:
@@ -284,13 +486,20 @@ class AgentRuntime:
         except Exception as e:
             logger.error(f"Stream execution error: {str(e)}")
             yield f"Error: {str(e)}"
+        finally:
+            self._execution_scope.reset(scope_token)
 
     def execute_agent_sync(self, agent_id: str, input_text: str) -> Dict[str, Any]:
         agent = AgentRegistry.get_agent(agent_id)
         if not agent:
             return {"success": False, "error": f"Agent {agent_id} not found"}
 
-        return agent.run(input_text)
+        execution_id = str(uuid.uuid4())
+        scope_token = self._execution_scope.set((execution_id, execution_id))
+        try:
+            return agent.run(input_text)
+        finally:
+            self._execution_scope.reset(scope_token)
 
     def get_agent(self, agent_id: str) -> Optional[LangChainAgent]:
         return AgentRegistry.get_agent(agent_id)

--- a/src/api/services/audit_log.py
+++ b/src/api/services/audit_log.py
@@ -7,6 +7,7 @@ Integrates with OpenTelemetry spans for automatic trace_id and span_id capture.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import uuid
@@ -50,20 +51,62 @@ CREATE TABLE IF NOT EXISTS audit_events (
     event_id TEXT PRIMARY KEY,
     agent_id TEXT NOT NULL,
     session_id TEXT NOT NULL,
+    run_id TEXT,
     span_id TEXT,
+    parent_span_id TEXT,
     event_type TEXT NOT NULL,
     payload TEXT NOT NULL,
     timestamp TEXT NOT NULL,
-    trace_id TEXT
+    trace_id TEXT,
+    actor_type TEXT NOT NULL DEFAULT 'agent',
+    actor_id TEXT,
+    actor_display TEXT,
+    policy_decision_id TEXT,
+    policy_refs TEXT NOT NULL DEFAULT '[]',
+    approval_id TEXT,
+    cost_record TEXT,
+    redaction_status TEXT NOT NULL DEFAULT 'none',
+    schema_version TEXT NOT NULL DEFAULT '1.0',
+    previous_hash TEXT,
+    integrity_hash TEXT
 )
 """
 AUDIT_TABLE_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_audit_agent_id ON audit_events(agent_id)",
     "CREATE INDEX IF NOT EXISTS idx_audit_session_id ON audit_events(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_audit_trace_id ON audit_events(trace_id)",
+    "CREATE INDEX IF NOT EXISTS idx_audit_run_id ON audit_events(run_id)",
     "CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp)",
     "CREATE INDEX IF NOT EXISTS idx_audit_event_type ON audit_events(event_type)",
+    """
+    CREATE INDEX IF NOT EXISTS idx_audit_missing_integrity_hash
+    ON audit_events(event_id)
+    WHERE integrity_hash IS NULL OR integrity_hash = ''
+    """,
 ]
+
+AUDIT_COLUMN_MIGRATIONS = {
+    "run_id": "TEXT",
+    "parent_span_id": "TEXT",
+    "actor_type": "TEXT NOT NULL DEFAULT 'agent'",
+    "actor_id": "TEXT",
+    "actor_display": "TEXT",
+    "policy_decision_id": "TEXT",
+    "policy_refs": "TEXT NOT NULL DEFAULT '[]'",
+    "approval_id": "TEXT",
+    "cost_record": "TEXT",
+    "redaction_status": "TEXT NOT NULL DEFAULT 'none'",
+    "schema_version": "TEXT NOT NULL DEFAULT '1.0'",
+    "previous_hash": "TEXT",
+    "integrity_hash": "TEXT",
+}
+
+AUDIT_SELECT_COLUMNS = """
+event_id, agent_id, session_id, run_id, span_id, parent_span_id,
+event_type, payload, timestamp, trace_id, actor_type, actor_id,
+actor_display, policy_decision_id, policy_refs, approval_id, cost_record,
+redaction_status, schema_version, previous_hash, integrity_hash
+""".strip()
 
 
 class AuditEventType(str, Enum):
@@ -88,17 +131,43 @@ class AuditEvent:
         event_type: AuditEventType,
         payload: dict[str, Any],
         timestamp: datetime,
+        run_id: str | None = None,
         span_id: str | None = None,
+        parent_span_id: str | None = None,
         trace_id: str | None = None,
+        actor_type: str = "agent",
+        actor_id: str | None = None,
+        actor_display: str | None = None,
+        policy_decision_id: str | None = None,
+        policy_refs: list[str] | None = None,
+        approval_id: str | None = None,
+        cost_record: dict[str, Any] | None = None,
+        redaction_status: str = "none",
+        schema_version: str = "1.0",
+        previous_hash: str | None = None,
+        integrity_hash: str | None = None,
     ):
         self.event_id = event_id
         self.agent_id = agent_id
         self.session_id = session_id
+        self.run_id = run_id
         self.span_id = span_id
+        self.parent_span_id = parent_span_id
         self.event_type = event_type
         self.payload = payload
         self.timestamp = timestamp
         self.trace_id = trace_id
+        self.actor_type = actor_type
+        self.actor_id = actor_id or agent_id
+        self.actor_display = actor_display
+        self.policy_decision_id = policy_decision_id
+        self.policy_refs = policy_refs or []
+        self.approval_id = approval_id
+        self.cost_record = cost_record
+        self.redaction_status = redaction_status
+        self.schema_version = schema_version
+        self.previous_hash = previous_hash
+        self.integrity_hash = integrity_hash
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary representation."""
@@ -106,35 +175,99 @@ class AuditEvent:
             "event_id": str(self.event_id),
             "agent_id": self.agent_id,
             "session_id": self.session_id,
+            "run_id": self.run_id,
             "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
             "event_type": self.event_type.value,
             "payload": self.payload,
             "timestamp": self.timestamp.isoformat(),
             "trace_id": self.trace_id,
+            "actor_type": self.actor_type,
+            "actor_id": self.actor_id,
+            "actor_display": self.actor_display,
+            "policy_decision_id": self.policy_decision_id,
+            "policy_refs": self.policy_refs,
+            "approval_id": self.approval_id,
+            "cost_record": self.cost_record,
+            "redaction_status": self.redaction_status,
+            "schema_version": self.schema_version,
+            "previous_hash": self.previous_hash,
+            "integrity_hash": self.integrity_hash,
         }
+
+    @property
+    def chain_key(self) -> str:
+        """Return the stable run/session key used for integrity chaining."""
+        return self.run_id or self.session_id
+
+    def compute_integrity_hash(self) -> str:
+        """Compute a deterministic SHA-256 digest over the event and prior link."""
+        content = self.to_dict()
+        content["integrity_hash"] = None
+        canonical = json.dumps(content, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode()).hexdigest()
 
     @classmethod
     def from_row(cls, row: tuple) -> "AuditEvent":
         """Create AuditEvent from a database row."""
+        if len(row) == 8:
+            event_id, agent_id, session_id, span_id, event_type, payload, timestamp, trace_id = row
+            return cls(
+                event_id=uuid.UUID(event_id),
+                agent_id=agent_id,
+                session_id=session_id,
+                span_id=span_id,
+                event_type=AuditEventType(event_type),
+                payload=json.loads(payload),
+                timestamp=datetime.fromisoformat(timestamp),
+                trace_id=trace_id,
+            )
+
         (
             event_id,
             agent_id,
             session_id,
+            run_id,
             span_id,
+            parent_span_id,
             event_type,
             payload,
             timestamp,
             trace_id,
+            actor_type,
+            actor_id,
+            actor_display,
+            policy_decision_id,
+            policy_refs,
+            approval_id,
+            cost_record,
+            redaction_status,
+            schema_version,
+            previous_hash,
+            integrity_hash,
         ) = row
         return cls(
             event_id=uuid.UUID(event_id),
             agent_id=agent_id,
             session_id=session_id,
+            run_id=run_id,
             span_id=span_id,
+            parent_span_id=parent_span_id,
             event_type=AuditEventType(event_type),
             payload=json.loads(payload),
             timestamp=datetime.fromisoformat(timestamp),
             trace_id=trace_id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            actor_display=actor_display,
+            policy_decision_id=policy_decision_id,
+            policy_refs=json.loads(policy_refs or "[]"),
+            approval_id=approval_id,
+            cost_record=json.loads(cost_record) if cost_record else None,
+            redaction_status=redaction_status,
+            schema_version=schema_version,
+            previous_hash=previous_hash,
+            integrity_hash=integrity_hash,
         )
 
 
@@ -145,6 +278,7 @@ class AuditQuery:
         self,
         agent_id: str | None = None,
         session_id: str | None = None,
+        run_id: str | None = None,
         time_range_start: datetime | None = None,
         time_range_end: datetime | None = None,
         event_type: AuditEventType | None = None,
@@ -153,6 +287,7 @@ class AuditQuery:
     ):
         self.agent_id = agent_id
         self.session_id = session_id
+        self.run_id = run_id
         self.time_range_start = time_range_start
         self.time_range_end = time_range_end
         self.event_type = event_type
@@ -174,9 +309,63 @@ class AuditLog:
             self._db = await aiosqlite.connect(self.db_path)
             self._db.row_factory = aiosqlite.Row
             await self._db.executescript(AUDIT_TABLE_SCHEMA)
+            await self._migrate_schema()
             for index_sql in AUDIT_TABLE_INDEXES:
                 await self._db.execute(index_sql)
+            if await self._needs_integrity_backfill():
+                await self._backfill_integrity_hashes()
             await self._db.commit()
+
+    async def _migrate_schema(self) -> None:
+        """Add governed-operation columns to databases created by older releases."""
+        assert self._db is not None
+        async with self._db.execute("PRAGMA table_info(audit_events)") as cursor:
+            existing_columns = {row[1] for row in await cursor.fetchall()}
+
+        for column, definition in AUDIT_COLUMN_MIGRATIONS.items():
+            if column not in existing_columns:
+                await self._db.execute(f"ALTER TABLE audit_events ADD COLUMN {column} {definition}")
+
+    async def _backfill_integrity_hashes(self) -> None:
+        """Hash-chain legacy rows in stable insertion order."""
+        assert self._db is not None
+        async with self._db.execute(
+            f"SELECT {AUDIT_SELECT_COLUMNS} FROM audit_events ORDER BY rowid"
+        ) as cursor:
+            rows = await cursor.fetchall()
+
+        prior_by_chain: dict[str, str] = {}
+        for row in rows:
+            event = AuditEvent.from_row(tuple(row))
+            if event.integrity_hash:
+                prior_by_chain[event.chain_key] = event.integrity_hash
+                continue
+
+            event.previous_hash = prior_by_chain.get(event.chain_key)
+            event.integrity_hash = event.compute_integrity_hash()
+            prior_by_chain[event.chain_key] = event.integrity_hash
+            await self._db.execute(
+                """
+                UPDATE audit_events
+                SET previous_hash = ?, integrity_hash = ?
+                WHERE event_id = ?
+                """,
+                (event.previous_hash, event.integrity_hash, str(event.event_id)),
+            )
+
+    async def _needs_integrity_backfill(self) -> bool:
+        """Check the partial index for legacy rows that still need hashes."""
+        assert self._db is not None
+        async with self._db.execute(
+            """
+            SELECT EXISTS(
+                SELECT 1 FROM audit_events
+                WHERE integrity_hash IS NULL OR integrity_hash = ''
+            )
+            """
+        ) as cursor:
+            row = await cursor.fetchone()
+        return bool(row[0])
 
     async def close(self) -> None:
         """Close the database connection."""
@@ -195,21 +384,59 @@ class AuditLog:
             await self.initialize()
 
         async with self._lock:
+            assert self._db is not None
+            if event.run_id:
+                previous_query = """
+                    SELECT integrity_hash FROM audit_events
+                    WHERE run_id = ? AND integrity_hash IS NOT NULL
+                    ORDER BY rowid DESC LIMIT 1
+                """
+                previous_params = (event.run_id,)
+            else:
+                previous_query = """
+                    SELECT integrity_hash FROM audit_events
+                    WHERE run_id IS NULL AND session_id = ? AND integrity_hash IS NOT NULL
+                    ORDER BY rowid DESC LIMIT 1
+                """
+                previous_params = (event.session_id,)
+
+            async with self._db.execute(previous_query, previous_params) as cursor:
+                previous_row = await cursor.fetchone()
+            event.previous_hash = previous_row[0] if previous_row else None
+            event.integrity_hash = event.compute_integrity_hash()
+
             await self._db.execute(
                 """
                 INSERT INTO audit_events
-                (event_id, agent_id, session_id, span_id, event_type, payload, timestamp, trace_id)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                (event_id, agent_id, session_id, run_id, span_id, parent_span_id,
+                 event_type, payload, timestamp, trace_id, actor_type, actor_id,
+                 actor_display, policy_decision_id, policy_refs, approval_id,
+                 cost_record, redaction_status, schema_version, previous_hash,
+                 integrity_hash)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     str(event.event_id),
                     event.agent_id,
                     event.session_id,
+                    event.run_id,
                     event.span_id,
+                    event.parent_span_id,
                     event.event_type.value,
                     json.dumps(event.payload),
                     event.timestamp.isoformat(),
                     event.trace_id,
+                    event.actor_type,
+                    event.actor_id,
+                    event.actor_display,
+                    event.policy_decision_id,
+                    json.dumps(event.policy_refs),
+                    event.approval_id,
+                    json.dumps(event.cost_record) if event.cost_record is not None else None,
+                    event.redaction_status,
+                    event.schema_version,
+                    event.previous_hash,
+                    event.integrity_hash,
                 ),
             )
             await self._db.commit()
@@ -245,7 +472,8 @@ class AuditLog:
         """Query audit events with filters and pagination.
 
         Args:
-            filters: Query filters including agent_id, session_id, time ranges, event_type, limit, skip.
+            filters: Query filters including agent_id, session_id, run_id, time ranges,
+                event_type, limit, and skip.
 
         Returns:
             List of matching audit events ordered by timestamp descending.
@@ -262,6 +490,9 @@ class AuditLog:
         if filters.session_id:
             conditions.append("session_id = ?")
             params.append(filters.session_id)
+        if filters.run_id:
+            conditions.append("run_id = ?")
+            params.append(filters.run_id)
         if filters.time_range_start:
             conditions.append("timestamp >= ?")
             params.append(filters.time_range_start.isoformat())
@@ -277,7 +508,7 @@ class AuditLog:
             where_clause = "WHERE " + " AND ".join(conditions)
 
         query_parts = [
-            "SELECT event_id, agent_id, session_id, span_id, event_type, payload, timestamp, trace_id",
+            f"SELECT {AUDIT_SELECT_COLUMNS}",
             "FROM audit_events",
         ]
         if where_clause:
@@ -311,8 +542,8 @@ class AuditLog:
 
         async with self._lock:
             async with self._db.execute(
-                """
-                SELECT event_id, agent_id, session_id, span_id, event_type, payload, timestamp, trace_id
+                f"""
+                SELECT {AUDIT_SELECT_COLUMNS}
                 FROM audit_events
                 WHERE trace_id = ?
                 ORDER BY timestamp ASC
@@ -322,6 +553,63 @@ class AuditLog:
                 rows = await cursor.fetchall()
 
         return [AuditEvent.from_row(tuple(row)) for row in rows]
+
+    async def export_evidence(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Export and verify a run or session evidence hash chain."""
+        if bool(run_id) == bool(session_id):
+            raise ValueError("Provide exactly one of run_id or session_id")
+        if not self._db:
+            await self.initialize()
+
+        field = "run_id" if run_id else "session_id"
+        value = run_id or session_id
+        async with self._lock:
+            assert self._db is not None
+            async with self._db.execute(
+                f"""
+                SELECT {AUDIT_SELECT_COLUMNS}
+                FROM audit_events
+                WHERE {field} = ?
+                ORDER BY rowid
+                """,
+                (value,),
+            ) as cursor:
+                rows = await cursor.fetchall()
+
+        events = [AuditEvent.from_row(tuple(row)) for row in rows]
+        errors: list[str] = []
+        previous_by_chain: dict[str, str | None] = {}
+        for event in events:
+            previous_hash = previous_by_chain.get(event.chain_key)
+            if event.previous_hash != previous_hash:
+                errors.append(f"Event {event.event_id} has an invalid previous_hash")
+            if event.integrity_hash != event.compute_integrity_hash():
+                errors.append(f"Event {event.event_id} has an invalid integrity_hash")
+            previous_by_chain[event.chain_key] = event.integrity_hash
+
+        chain_roots = sorted(root for root in previous_by_chain.values() if root)
+        if len(chain_roots) == 1:
+            chain_root = chain_roots[0]
+        elif chain_roots:
+            chain_root = hashlib.sha256("".join(chain_roots).encode()).hexdigest()
+        else:
+            chain_root = None
+
+        return {
+            "schema_version": "1.0",
+            "algorithm": "sha256",
+            field: value,
+            "event_count": len(events),
+            "chain_root": chain_root,
+            "verified": not errors,
+            "errors": errors,
+            "events": [event.to_dict() for event in events],
+        }
 
 
 # Global audit log instance

--- a/src/api/services/governance_runtime.py
+++ b/src/api/services/governance_runtime.py
@@ -1,0 +1,367 @@
+"""Canonical composition root for runtime security enforcement and evidence."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+import uuid
+
+from src.api.integrations.tool_names import RUNTIME_BUILTIN_TOOL_NAMES
+from src.api.services.audit_log import AuditEvent, AuditEventType, AuditLog, get_audit_log
+from src.security import (
+    ActionMediator,
+    ApprovalRequest,
+    ApprovalService,
+    ContextAccumulator,
+    NormalizedAction,
+    PolicyDecision,
+    PolicyDecisionResult,
+    PolicyEngine,
+    ReceiptGenerator,
+    TelemetryEventType,
+    TelemetryExporter,
+)
+from src.security.context import SessionContext
+from src.security.policy import PolicyRule, PolicySet
+from src.security.receipts import ActionReceipt
+
+AuditLogFactory = Callable[[], Awaitable[AuditLog]]
+
+
+@dataclass
+class GovernanceEvaluation:
+    """A normalized action and its pre-execution policy decision."""
+
+    action: NormalizedAction
+    context: SessionContext
+    decision: PolicyDecisionResult
+    decision_id: str
+    run_id: str
+    actor_type: str
+    actor_id: str
+    actor_display: str | None
+    policy_refs: list[str]
+    approval: ApprovalRequest | None = None
+
+
+class GovernanceRuntime:
+    """Coordinate mediation, policy, approvals, receipts, telemetry, and audit."""
+
+    SAFE_BUILTIN_TOOLS = RUNTIME_BUILTIN_TOOL_NAMES
+
+    def __init__(
+        self,
+        *,
+        mediator: ActionMediator | None = None,
+        context_accumulator: ContextAccumulator | None = None,
+        policy_engine: PolicyEngine | None = None,
+        approval_service: ApprovalService | None = None,
+        receipt_generator: ReceiptGenerator | None = None,
+        telemetry_exporter: TelemetryExporter | None = None,
+        audit_log_factory: AuditLogFactory = get_audit_log,
+        install_default_policy: bool = True,
+    ) -> None:
+        self.mediator = mediator or ActionMediator()
+        self.context_accumulator = context_accumulator or ContextAccumulator()
+        self.policy_engine = policy_engine or PolicyEngine()
+        self.approval_service = approval_service or ApprovalService()
+        self.receipt_generator = receipt_generator or ReceiptGenerator()
+        self.telemetry_exporter = telemetry_exporter or TelemetryExporter()
+        self.audit_log_factory = audit_log_factory
+        self._evidence_lock = asyncio.Lock()
+
+        if install_default_policy and not self.policy_engine.list_policies():
+            self.policy_engine.add_policy(self._default_policy(), set_default=True)
+
+    @classmethod
+    def _default_policy(cls) -> PolicySet:
+        policy = PolicySet(
+            id="mutx-runtime-default",
+            name="MUTX runtime default",
+            description="Allow low-risk built-ins and deny unconfigured custom tools.",
+            default_decision=PolicyDecision.DENY,
+        )
+        for priority, tool_name in enumerate(cls.SAFE_BUILTIN_TOOLS, start=10):
+            policy.add_rule(
+                PolicyRule(
+                    id=f"allow-{tool_name}",
+                    name=f"Allow {tool_name}",
+                    priority=priority,
+                    tool_pattern=tool_name,
+                    action=PolicyDecision.ALLOW,
+                    reason="Low-risk built-in tool",
+                )
+            )
+        return policy
+
+    def authorize(
+        self,
+        *,
+        tool_name: str,
+        tool_args: dict[str, Any],
+        agent_id: str,
+        session_id: str,
+        run_id: str,
+        user_id: str = "",
+        actor_type: str = "agent",
+        actor_id: str | None = None,
+        actor_display: str | None = None,
+        trigger: str = "agent",
+    ) -> GovernanceEvaluation:
+        """Normalize and evaluate a tool call before its handler can run."""
+        resolved_actor_id = actor_id or agent_id
+        context = self.context_accumulator.get_context(session_id)
+        if context is None:
+            context = self.context_accumulator.create_session(
+                session_id=session_id,
+                agent_id=agent_id,
+                user_id=user_id,
+                metadata={"run_id": run_id},
+            )
+
+        action = self.mediator.intercept(
+            tool_name=tool_name,
+            tool_args=tool_args,
+            agent_id=agent_id,
+            session_id=session_id,
+            user_id=user_id,
+            trigger=trigger,
+            runtime="mutx-agent-runtime",
+        )
+        decision = self.policy_engine.evaluate(action, context)
+        policy_refs = self._resolve_policy_refs(decision)
+        decision_id = str(uuid.uuid4())
+        approval = None
+        if decision.is_deferred:
+            approval = self.approval_service.request_approval(
+                action=action,
+                context=context,
+                reason=decision.reason,
+                metadata={"run_id": run_id, "policy_decision_id": decision_id},
+            )
+
+        return GovernanceEvaluation(
+            action=action,
+            context=context,
+            decision=decision,
+            decision_id=decision_id,
+            run_id=run_id,
+            actor_type=actor_type,
+            actor_id=resolved_actor_id,
+            actor_display=actor_display,
+            policy_refs=policy_refs,
+            approval=approval,
+        )
+
+    def _resolve_policy_refs(self, decision: PolicyDecisionResult) -> list[str]:
+        """Identify the policy set and rule that produced a decision."""
+        policy_summaries = self.policy_engine.list_policies()
+        policy_id = None
+        if decision.rule_id:
+            for summary in policy_summaries:
+                policy = self.policy_engine.get_policy(summary["id"])
+                if policy and policy.get_rule(decision.rule_id):
+                    policy_id = policy.id
+                    break
+        elif len(policy_summaries) == 1:
+            policy_id = policy_summaries[0]["id"]
+
+        return [ref for ref in (policy_id, decision.rule_id) if ref]
+
+    async def record_outcome(
+        self,
+        evaluation: GovernanceEvaluation,
+        *,
+        outcome: str,
+        outcome_detail: str = "",
+        output_preview: str | None = None,
+        error: str | None = None,
+        cost_record: dict[str, Any] | None = None,
+        redaction_status: str = "none",
+        telemetry_type: TelemetryEventType | None = None,
+    ) -> tuple[ActionReceipt, AuditEvent]:
+        """Generate a receipt and append hash-chained governed-operation evidence."""
+        async with self._evidence_lock:
+            return await self._record_outcome(
+                evaluation,
+                outcome=outcome,
+                outcome_detail=outcome_detail,
+                output_preview=output_preview,
+                error=error,
+                cost_record=cost_record,
+                redaction_status=redaction_status,
+                telemetry_type=telemetry_type,
+            )
+
+    async def _record_outcome(
+        self,
+        evaluation: GovernanceEvaluation,
+        *,
+        outcome: str,
+        outcome_detail: str = "",
+        output_preview: str | None = None,
+        error: str | None = None,
+        cost_record: dict[str, Any] | None = None,
+        redaction_status: str = "none",
+        telemetry_type: TelemetryEventType | None = None,
+    ) -> tuple[ActionReceipt, AuditEvent]:
+        """Persist evidence while the caller holds the evidence sequencing lock."""
+        decision = evaluation.decision
+        if decision.is_denied:
+            effect = "DENY"
+            resolved_telemetry_type = TelemetryEventType.ACTION_DENIED
+        elif decision.is_deferred:
+            effect = "DEFER"
+            resolved_telemetry_type = TelemetryEventType.ACTION_DEFERRED
+        else:
+            effect = "PERMIT"
+            resolved_telemetry_type = (
+                TelemetryEventType.ACTION_FAILED if error else TelemetryEventType.ACTION_EXECUTED
+            )
+        resolved_telemetry_type = telemetry_type or resolved_telemetry_type
+
+        receipt = self.receipt_generator.generate(
+            action=evaluation.action,
+            context=evaluation.context,
+            decision=decision,
+            outcome=outcome,
+            outcome_detail=outcome_detail,
+            metadata={
+                "run_id": evaluation.run_id,
+                "policy_decision_id": evaluation.decision_id,
+                "approval_id": evaluation.approval.id if evaluation.approval else None,
+            },
+        )
+        audit_event = self._build_audit_event(
+            evaluation,
+            receipt=receipt,
+            event_type=AuditEventType.POLICY_CHECK,
+            outcome=outcome,
+            cost_record=cost_record,
+            redaction_status=redaction_status,
+        )
+        audit_log = await self.audit_log_factory()
+        await audit_log.log_with_otel_context(audit_event)
+
+        self.context_accumulator.record_action(
+            evaluation.action.session_id,
+            evaluation.action,
+            effect,
+            decision_reason=decision.reason,
+            output_preview=output_preview,
+            error=error,
+        )
+        self.telemetry_exporter.export_security_event(
+            event_type=resolved_telemetry_type,
+            action=evaluation.action,
+            decision=decision,
+            receipt=receipt,
+            error=error,
+            metadata={"run_id": evaluation.run_id},
+        )
+        return receipt, audit_event
+
+    async def record_authorization(
+        self,
+        evaluation: GovernanceEvaluation,
+    ) -> tuple[ActionReceipt, AuditEvent]:
+        """Durably record an allow/modify decision before a tool can execute."""
+        return await self.record_outcome(
+            evaluation,
+            outcome="authorized",
+            outcome_detail=evaluation.decision.reason,
+            telemetry_type=TelemetryEventType.ACTION_ALLOWED,
+        )
+
+    async def record_execution_result(
+        self,
+        evaluation: GovernanceEvaluation,
+        *,
+        authorization_receipt: ActionReceipt,
+        outcome: str,
+        output_preview: str | None = None,
+        error: str | None = None,
+        cost_record: dict[str, Any] | None = None,
+        redaction_status: str = "none",
+    ) -> AuditEvent:
+        """Append the result linked to a previously persisted authorization."""
+        audit_event = self._build_audit_event(
+            evaluation,
+            receipt=authorization_receipt,
+            event_type=AuditEventType.TOOL_CALL,
+            outcome=outcome,
+            cost_record=cost_record,
+            redaction_status=redaction_status,
+            output_preview=output_preview,
+            error=error,
+        )
+        audit_log = await self.audit_log_factory()
+        await audit_log.log_with_otel_context(audit_event)
+        self.telemetry_exporter.export_security_event(
+            event_type=(
+                TelemetryEventType.ACTION_FAILED if error else TelemetryEventType.ACTION_EXECUTED
+            ),
+            action=evaluation.action,
+            decision=evaluation.decision,
+            receipt=authorization_receipt,
+            error=error,
+            metadata={"run_id": evaluation.run_id},
+            track_metrics=False,
+        )
+        return audit_event
+
+    @staticmethod
+    def _build_audit_event(
+        evaluation: GovernanceEvaluation,
+        *,
+        receipt: ActionReceipt,
+        event_type: AuditEventType,
+        outcome: str,
+        cost_record: dict[str, Any] | None = None,
+        redaction_status: str = "none",
+        output_preview: str | None = None,
+        error: str | None = None,
+    ) -> AuditEvent:
+        """Build a governed-operation event linked to its authorization receipt."""
+        return AuditEvent(
+            event_id=uuid.uuid4(),
+            agent_id=evaluation.action.agent_id,
+            session_id=evaluation.action.session_id,
+            run_id=evaluation.run_id,
+            event_type=event_type,
+            payload={
+                "action_id": evaluation.action.id,
+                "action_hash": evaluation.action.action_hash,
+                "tool_name": evaluation.action.tool_name,
+                "decision": evaluation.decision.decision.value,
+                "reason": evaluation.decision.reason,
+                "outcome": outcome,
+                "receipt_id": receipt.receipt_id,
+                "receipt_hash": receipt.compute_hash(),
+                "output_preview": output_preview,
+                "error": error,
+            },
+            timestamp=datetime.now(timezone.utc),
+            actor_type=evaluation.actor_type,
+            actor_id=evaluation.actor_id,
+            actor_display=evaluation.actor_display,
+            policy_decision_id=evaluation.decision_id,
+            policy_refs=evaluation.policy_refs,
+            approval_id=evaluation.approval.id if evaluation.approval else None,
+            cost_record=cost_record,
+            redaction_status=redaction_status,
+        )
+
+
+_governance_runtime: GovernanceRuntime | None = None
+
+
+def get_governance_runtime() -> GovernanceRuntime:
+    """Return the process-wide security composition root."""
+    global _governance_runtime
+    if _governance_runtime is None:
+        _governance_runtime = GovernanceRuntime()
+    return _governance_runtime

--- a/src/security/telemetry.py
+++ b/src/security/telemetry.py
@@ -214,6 +214,7 @@ class TelemetryExporter:
         receipt: Optional[ActionReceipt] = None,
         error: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
+        track_metrics: bool = True,
     ) -> TelemetryEvent:
         """
         Export a security event.
@@ -225,6 +226,7 @@ class TelemetryExporter:
             receipt: Optional receipt for audit
             error: Optional error message
             metadata: Additional metadata
+            track_metrics: Whether this event represents a new policy evaluation
 
         Returns:
             The created TelemetryEvent
@@ -249,7 +251,8 @@ class TelemetryExporter:
         )
 
         self._queue_event(event)
-        self._update_metrics(event_type, decision)
+        if track_metrics:
+            self._update_metrics(event_type, decision)
 
         return event
 

--- a/tests/api/test_governed_runtime.py
+++ b/tests/api/test_governed_runtime.py
@@ -1,0 +1,624 @@
+import ast
+import asyncio
+import runpy
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from src.api.config import get_settings
+from src.api.services.agent_runtime import AgentRuntime, RuntimeConfig
+from src.api.services.audit_log import AuditEvent, AuditEventType, AuditLog, AuditQuery
+from src.api.services.auth import TokenPayload, create_access_token
+from src.api.services.governance_runtime import GovernanceRuntime
+from src.api.integrations.langchain_agent import (
+    AgentConfig,
+    AgentRegistry,
+    LangChainAgent,
+    LLMProvider,
+    ToolDefinition,
+)
+from src.security import PolicyDecision, PolicyEngine
+from src.security.policy import PolicyRule, PolicySet
+
+
+def _governance_for(
+    decision: PolicyDecision,
+    audit_log: AuditLog,
+) -> GovernanceRuntime:
+    engine = PolicyEngine()
+    policy = PolicySet(
+        id=f"test-{decision.value}",
+        name=f"Test {decision.value}",
+        default_decision=PolicyDecision.DENY,
+    )
+    policy.add_rule(
+        PolicyRule(
+            id=f"rule-{decision.value}",
+            name=f"Rule {decision.value}",
+            tool_pattern="test_tool",
+            action=decision,
+            reason=f"Test {decision.value} decision",
+        )
+    )
+    engine.add_policy(policy, set_default=True)
+
+    async def get_test_audit_log() -> AuditLog:
+        return audit_log
+
+    return GovernanceRuntime(
+        policy_engine=engine,
+        audit_log_factory=get_test_audit_log,
+        install_default_policy=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_security_denial_blocks_handler_and_emits_evidence(tmp_path: Path) -> None:
+    audit_log = AuditLog(str(tmp_path / "deny.db"))
+    await audit_log.initialize()
+    governance = _governance_for(PolicyDecision.DENY, audit_log)
+    runtime = AgentRuntime(RuntimeConfig(vector_store_enabled=False), governance=governance)
+    handler_called = False
+
+    async def handler(_parameters: dict[str, object]) -> str:
+        nonlocal handler_called
+        handler_called = True
+        return "should not execute"
+
+    runtime.tool_handler.register_handler("test_tool", handler)
+    result = await runtime.tool_handler.execute_tool(
+        "test_tool",
+        {"value": "blocked"},
+        agent_id="agent-1",
+        session_id="session-1",
+        run_id="run-1",
+        actor_id="user-1",
+        actor_display="Test Operator",
+    )
+
+    assert handler_called is False
+    assert result["decision"] == "deny"
+    assert governance.receipt_generator.get_receipt(result["receipt_id"]) is not None
+
+    events = await audit_log.query(AuditQuery(run_id="run-1"))
+    assert len(events) == 1
+    event = events[0]
+    assert event.actor_id == "user-1"
+    assert event.actor_display == "Test Operator"
+    assert event.policy_refs == ["test-deny", "rule-deny"]
+    assert event.policy_decision_id
+    assert event.integrity_hash == result["integrity_hash"]
+    assert len(event.integrity_hash) == 64
+    await audit_log.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_security_defer_creates_approval_without_execution(tmp_path: Path) -> None:
+    audit_log = AuditLog(str(tmp_path / "defer.db"))
+    await audit_log.initialize()
+    governance = _governance_for(PolicyDecision.DEFER, audit_log)
+    runtime = AgentRuntime(RuntimeConfig(vector_store_enabled=False), governance=governance)
+    handler_called = False
+
+    def handler(_parameters: dict[str, object]) -> str:
+        nonlocal handler_called
+        handler_called = True
+        return "should not execute"
+
+    runtime.tool_handler.register_handler("test_tool", handler)
+    result = await runtime.tool_handler.execute_tool(
+        "test_tool",
+        {},
+        agent_id="agent-2",
+        session_id="session-2",
+        run_id="run-2",
+    )
+
+    assert handler_called is False
+    assert result["decision"] == "defer"
+    approval = governance.approval_service.get_request(result["approval_id"])
+    assert approval is not None
+    assert approval.metadata["run_id"] == "run-2"
+
+    events = await audit_log.query(AuditQuery(run_id="run-2"))
+    assert events[0].approval_id == approval.id
+    assert events[0].payload["outcome"] == "approval_required"
+    await audit_log.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_security_allow_executes_and_hash_chains_events(tmp_path: Path) -> None:
+    audit_log = AuditLog(str(tmp_path / "allow.db"))
+    await audit_log.initialize()
+    governance = _governance_for(PolicyDecision.ALLOW, audit_log)
+    runtime = AgentRuntime(RuntimeConfig(vector_store_enabled=False), governance=governance)
+    calls: list[dict[str, object]] = []
+
+    def handler(parameters: dict[str, object]) -> str:
+        calls.append(parameters)
+        return "executed"
+
+    runtime.tool_handler.register_handler("test_tool", handler)
+    for value in (1, 2):
+        result = await runtime.tool_handler.execute_tool(
+            "test_tool",
+            {"value": value},
+            agent_id="agent-3",
+            session_id="session-3",
+            run_id="run-3",
+        )
+        assert result == "executed"
+
+    assert calls == [{"value": 1}, {"value": 2}]
+    metrics = governance.telemetry_exporter.get_metrics_summary()
+    assert metrics["total_evaluations"] == 2
+    assert metrics["permits"] == 2
+    receipts = governance.receipt_generator.get_receipts_for_session("session-3")
+    assert receipts[0].prior_action_hashes == []
+    assert receipts[1].prior_action_hashes == [receipts[0].action_hash]
+    export = await audit_log.export_evidence(run_id="run-3")
+    assert export["verified"] is True
+    assert export["event_count"] == 4
+    for previous, current in zip(export["events"], export["events"][1:]):
+        assert current["previous_hash"] == previous["integrity_hash"]
+    assert export["chain_root"] == export["events"][-1]["integrity_hash"]
+    await audit_log.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_security_modify_passes_only_modified_args(tmp_path: Path) -> None:
+    audit_log = AuditLog(str(tmp_path / "modify.db"))
+    await audit_log.initialize()
+    governance = _governance_for(PolicyDecision.MODIFY, audit_log)
+    runtime = AgentRuntime(RuntimeConfig(vector_store_enabled=False), governance=governance)
+    calls: list[dict[str, object]] = []
+
+    def handler(parameters: dict[str, object]) -> str:
+        calls.append(parameters)
+        return "executed"
+
+    result = await runtime.tool_handler.execute_tool(
+        "test_tool",
+        {"value": 7},
+        agent_id="agent-modify",
+        session_id="session-modify",
+        run_id="run-modify",
+        handler_override=handler,
+    )
+
+    assert result == "executed"
+    assert calls == [{"value": 7}]
+    await audit_log.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_langchain_bridge_preserves_execution_identity(tmp_path: Path) -> None:
+    from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, use_span
+
+    audit_log = AuditLog(str(tmp_path / "bridge.db"))
+    await audit_log.initialize()
+    governance = _governance_for(PolicyDecision.ALLOW, audit_log)
+    runtime = AgentRuntime(RuntimeConfig(vector_store_enabled=False), governance=governance)
+    runtime._bind_event_loop()
+    scope_token = runtime._execution_scope.set(("run-bridge", "session-bridge"))
+    span = NonRecordingSpan(
+        SpanContext(
+            trace_id=0x0123456789ABCDEF0123456789ABCDEF,
+            span_id=0xFEDCBA9876543210,
+            is_remote=False,
+            trace_flags=TraceFlags.SAMPLED,
+        )
+    )
+    try:
+        with use_span(span, end_on_exit=False):
+            results = await asyncio.gather(
+                *(
+                    asyncio.to_thread(
+                        runtime._execute_langchain_tool,
+                        "agent-bridge",
+                        "test_tool",
+                        {"value": value},
+                        lambda parameters: parameters["value"],
+                    )
+                    for value in ("first", "second")
+                )
+            )
+    finally:
+        runtime._execution_scope.reset(scope_token)
+
+    assert results == ["first", "second"]
+    events = await audit_log.query(AuditQuery(run_id="run-bridge"))
+    assert len(events) == 4
+    assert all(event.session_id == "session-bridge" for event in events)
+    assert all(event.agent_id == "agent-bridge" for event in events)
+    assert all(event.trace_id == "0123456789abcdef0123456789abcdef" for event in events)
+    assert all(event.span_id == "fedcba9876543210" for event in events)
+    receipts = governance.receipt_generator.get_receipts_for_session("session-bridge")
+    assert receipts[0].prior_action_hashes == []
+    assert receipts[1].prior_action_hashes == [receipts[0].action_hash]
+    await audit_log.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_security_blocks_execution_when_authorization_audit_fails() -> None:
+    class FailingAuditLog:
+        async def log_with_otel_context(self, _event: AuditEvent) -> None:
+            raise OSError("audit unavailable")
+
+    async def get_failing_audit_log() -> FailingAuditLog:
+        return FailingAuditLog()
+
+    engine = PolicyEngine()
+    policy = PolicySet(
+        id="test-fail-closed",
+        name="Test fail closed",
+        default_decision=PolicyDecision.ALLOW,
+    )
+    engine.add_policy(policy, set_default=True)
+    governance = GovernanceRuntime(
+        policy_engine=engine,
+        audit_log_factory=get_failing_audit_log,
+        install_default_policy=False,
+    )
+    runtime = AgentRuntime(RuntimeConfig(vector_store_enabled=False), governance=governance)
+    handler_called = False
+
+    def handler(_parameters: dict[str, object]) -> str:
+        nonlocal handler_called
+        handler_called = True
+        return "should not execute"
+
+    result = await runtime.tool_handler.execute_tool(
+        "test_tool",
+        {},
+        agent_id="agent-fail-closed",
+        session_id="session-fail-closed",
+        run_id="run-fail-closed",
+        handler_override=handler,
+    )
+
+    assert handler_called is False
+    assert result == {
+        "error": "Tool execution blocked because authorization evidence could not be persisted",
+        "decision": "allow",
+        "reason": "No matching rule; default: allow",
+    }
+
+
+@pytest.mark.asyncio
+async def test_runtime_reserved_handlers_cannot_be_overwritten() -> None:
+    runtime = AgentRuntime(RuntimeConfig(vector_store_enabled=False))
+    await runtime.start()
+    original_calculator = runtime.tool_handler.get_handler("calculator")
+
+    with pytest.raises(ValueError, match="reserved.*calculator"):
+        runtime.tool_handler.register_handler(
+            "calculator", lambda _parameters: "arbitrary side effect"
+        )
+
+    assert runtime.tool_handler.get_handler("calculator") is original_calculator
+    await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_stream_runs_governed_tools_off_owner_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_log = AuditLog(str(tmp_path / "stream.db"))
+    await audit_log.initialize()
+    governance = _governance_for(PolicyDecision.ALLOW, audit_log)
+    runtime = AgentRuntime(RuntimeConfig(vector_store_enabled=False), governance=governance)
+
+    class StreamingAgent:
+        def stream_run(self, _input_text: str):
+            yield runtime._execute_langchain_tool(
+                "agent-stream",
+                "test_tool",
+                {"value": "streamed"},
+                lambda parameters: parameters["value"],
+            )
+
+    monkeypatch.setattr(AgentRegistry, "get_agent", lambda _agent_id: StreamingAgent())
+
+    chunks = [chunk async for chunk in runtime.execute_agent_stream("agent-stream", "run")]
+
+    assert chunks == ["streamed"]
+    events = await audit_log.query(AuditQuery(agent_id="agent-stream"))
+    assert [event.event_type for event in events] == [
+        AuditEventType.TOOL_CALL,
+        AuditEventType.POLICY_CHECK,
+    ]
+    await audit_log.close()
+
+
+@pytest.mark.asyncio
+async def test_audit_log_migrates_and_hashes_legacy_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE audit_events (
+                event_id TEXT PRIMARY KEY,
+                agent_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                span_id TEXT,
+                event_type TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                trace_id TEXT
+            )
+            """
+        )
+        now = datetime.now(timezone.utc)
+        connection.executemany(
+            "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    "00000000-0000-4000-8000-000000000001",
+                    "legacy-agent",
+                    "legacy-session",
+                    None,
+                    AuditEventType.TOOL_CALL.value,
+                    '{"tool_name":"first-inserted"}',
+                    (now + timedelta(minutes=1)).isoformat(),
+                    None,
+                ),
+                (
+                    "00000000-0000-4000-8000-000000000002",
+                    "legacy-agent",
+                    "legacy-session",
+                    None,
+                    AuditEventType.TOOL_CALL.value,
+                    '{"tool_name":"second-inserted"}',
+                    now.isoformat(),
+                    None,
+                ),
+            ],
+        )
+
+    audit_log = AuditLog(str(db_path))
+    await audit_log.initialize()
+    export = await audit_log.export_evidence(session_id="legacy-session")
+
+    assert export["verified"] is True
+    assert export["event_count"] == 2
+    assert len(export["events"][0]["integrity_hash"]) == 64
+    assert export["events"][1]["previous_hash"] == export["events"][0]["integrity_hash"]
+    assert export["events"][0]["schema_version"] == "1.0"
+    await audit_log.close()
+
+
+@pytest.mark.asyncio
+async def test_audit_log_skips_completed_integrity_backfill(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "already-hashed.db"
+    audit_log = AuditLog(str(db_path))
+    await audit_log.initialize()
+    await audit_log.log(
+        AuditEvent(
+            event_id=uuid.uuid4(),
+            agent_id="agent",
+            session_id="session",
+            run_id="run",
+            event_type=AuditEventType.POLICY_CHECK,
+            payload={"decision": "allow"},
+            timestamp=datetime.now(timezone.utc),
+        )
+    )
+    await audit_log.close()
+
+    reopened_log = AuditLog(str(db_path))
+    backfill_called = False
+
+    async def unexpected_backfill() -> None:
+        nonlocal backfill_called
+        backfill_called = True
+
+    monkeypatch.setattr(reopened_log, "_backfill_integrity_hashes", unexpected_backfill)
+    await reopened_log.initialize()
+
+    assert backfill_called is False
+    await reopened_log.close()
+
+
+@pytest.mark.asyncio
+async def test_audit_evidence_export_detects_persisted_tampering(tmp_path: Path) -> None:
+    audit_log = AuditLog(str(tmp_path / "tampered.db"))
+    await audit_log.initialize()
+    event = AuditEvent(
+        event_id=uuid.uuid4(),
+        agent_id="agent",
+        session_id="session",
+        run_id="run",
+        event_type=AuditEventType.POLICY_CHECK,
+        payload={"decision": "allow"},
+        timestamp=datetime.now(timezone.utc),
+    )
+    await audit_log.log(event)
+
+    assert audit_log._db is not None
+    await audit_log._db.execute(
+        "UPDATE audit_events SET payload = ? WHERE event_id = ?",
+        ('{"decision":"deny"}', str(event.event_id)),
+    )
+    await audit_log._db.commit()
+
+    export = await audit_log.export_evidence(run_id="run")
+    assert export["verified"] is False
+    assert "invalid integrity_hash" in export["errors"][0]
+    await audit_log.close()
+
+
+def test_audit_event_integrity_hash_detects_tampering() -> None:
+    event = AuditEvent(
+        event_id=uuid.uuid4(),
+        agent_id="agent",
+        session_id="session",
+        run_id="run",
+        event_type=AuditEventType.POLICY_CHECK,
+        payload={"decision": "allow"},
+        timestamp=datetime.now(timezone.utc),
+    )
+    original_hash = event.compute_integrity_hash()
+
+    event.payload["decision"] = "deny"
+
+    assert event.compute_integrity_hash() != original_hash
+
+
+def test_langchain_example_does_not_execute_eval() -> None:
+    example_path = Path(__file__).parents[2] / "examples" / "langchain_agent.py"
+    tree = ast.parse(example_path.read_text())
+
+    eval_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "eval"
+    ]
+    assert eval_calls == []
+
+    namespace = runpy.run_path(str(example_path))
+    evaluate = namespace["_evaluate_arithmetic"]
+    assert evaluate(ast.parse("2 + 3 * 4", mode="eval")) == 14
+    with pytest.raises(ValueError, match="Unsupported expression"):
+        evaluate(ast.parse("__import__('os').system('id')", mode="eval"))
+
+
+def test_langchain_tools_are_wrapped_by_runtime_executor() -> None:
+    captured: dict[str, object] = {}
+
+    def tool_handler(parameters: dict[str, object]) -> str:
+        captured["handler_parameters"] = parameters
+        return "wrapped-result"
+
+    def tool_executor(
+        agent_id: str,
+        tool_name: str,
+        parameters: dict[str, object],
+        handler,
+    ) -> object:
+        captured.update(
+            {
+                "agent_id": agent_id,
+                "tool_name": tool_name,
+                "parameters": parameters,
+            }
+        )
+        return handler(parameters)
+
+    agent = object.__new__(LangChainAgent)
+    agent.agent_id = "agent-wrapped"
+    agent.config = AgentConfig(
+        name="wrapped",
+        provider=LLMProvider.OPENAI,
+        model="test-model",
+        tools=[
+            ToolDefinition(
+                name="test_tool",
+                description="Test governed tool",
+                function=tool_handler,
+            )
+        ],
+        tool_executor=tool_executor,
+    )
+
+    tools = agent._initialize_tools()
+    test_tool = next(tool for tool in tools if tool.name == "test_tool")
+
+    assert test_tool.invoke({}) == "wrapped-result"
+    assert captured == {
+        "agent_id": "agent-wrapped",
+        "tool_name": "test_tool",
+        "parameters": {},
+        "handler_parameters": {},
+    }
+
+
+def test_langchain_custom_tools_cannot_shadow_governed_builtins() -> None:
+    agent = object.__new__(LangChainAgent)
+    agent.agent_id = "agent-reserved"
+    agent.config = AgentConfig(
+        name="reserved",
+        provider=LLMProvider.OPENAI,
+        model="test-model",
+        tools=[
+            ToolDefinition(
+                name="calculator",
+                description="Attempt to shadow the allowlisted calculator",
+                function=lambda _parameters: "arbitrary side effect",
+            )
+        ],
+        tool_executor=lambda *_args: None,
+    )
+
+    with pytest.raises(ValueError, match="Custom tool names are reserved.*calculator"):
+        agent._initialize_tools()
+
+
+@pytest.mark.asyncio
+async def test_audit_evidence_export_route_is_authenticated_and_verified(
+    client_no_auth: AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.api.routes.audit as audit_route
+
+    audit_log = AuditLog(str(tmp_path / "export.db"))
+    await audit_log.initialize()
+    event = AuditEvent(
+        event_id=uuid.uuid4(),
+        agent_id="export-agent",
+        session_id="export-session",
+        run_id="export-run",
+        event_type=AuditEventType.POLICY_CHECK,
+        payload={"decision": "allow"},
+        timestamp=datetime.now(timezone.utc),
+        actor_id="operator-1",
+        policy_decision_id="decision-1",
+        policy_refs=["policy-1", "rule-1"],
+    )
+    await audit_log.log(event)
+
+    async def get_test_audit_log() -> AuditLog:
+        return audit_log
+
+    monkeypatch.setattr(audit_route, "get_audit_log", get_test_audit_log)
+
+    unauthorized = await client_no_auth.get("/v1/audit/export?run_id=export-run")
+    assert unauthorized.status_code == 401
+
+    token = create_access_token(
+        TokenPayload(
+            sub="audit-admin-1",
+            email="audit@example.com",
+            roles=["AUDIT_ADMIN"],
+            exp=datetime.now(timezone.utc) + timedelta(hours=1),
+        ),
+        get_settings().jwt_secret,
+    )
+    response = await client_no_auth.get(
+        "/v1/audit/export?run_id=export-run",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    export = response.json()
+    assert export["verified"] is True
+    assert export["run_id"] == "export-run"
+    assert export["event_count"] == 1
+    assert export["chain_root"] == event.integrity_hash
+    assert export["events"][0]["policy_refs"] == ["policy-1", "rule-1"]
+
+    invalid = await client_no_auth.get(
+        "/v1/audit/export",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert invalid.status_code == 400
+    await audit_log.close()


### PR DESCRIPTION
## Summary

- route every AgentRuntime LangChain tool call through ActionMediator and PolicyEngine before execution
- fail closed unless allow/MODIFY authorization evidence is durably persisted before the handler runs, then append linked execution-result evidence without double-counting policy metrics
- reserve allowlisted built-in names through a dependency-light shared module and protect trusted handler registrations from custom overrides
- bind async agent runtimes to one owning event loop and route concurrent worker-thread and streaming tool calls back to it while preserving runtime and OpenTelemetry context
- block denied calls with receipts and defer approval-required calls through ApprovalService
- extend audit events to RunEvent v1 evidence fields with migration-safe SHA-256 chains, serialized receipt provenance, indexed one-time legacy backfill, and authenticated export
- share the governance composition root with the existing security API and regenerate API contracts
- replace the standalone LangChain example eval pattern with bounded AST arithmetic and a regression guard

## Validation

- `python -m pytest tests/api -q` — 825 passed on `99cc6d9a`
- focused governance suite — 16 passed on `99cc6d9a`
- focused runtime/audit/optional-import/telemetry suite — 66 passed on `99cc6d9a`
- `ruff check src/api/integrations/tool_names.py src/api/integrations/langchain_agent.py src/api/services/agent_runtime.py src/api/services/audit_log.py src/api/services/governance_runtime.py src/security/telemetry.py tests/api/test_governed_runtime.py` — passed
- `ruff format --check src/api/integrations/tool_names.py src/api/integrations/langchain_agent.py src/api/services/agent_runtime.py src/api/services/audit_log.py src/api/services/governance_runtime.py src/security/telemetry.py tests/api/test_governed_runtime.py` — passed
- generated OpenAPI/frontend artifacts verification — passed

Closes #3788
Closes #3781
