### PR TITLE
fix(legal): correct upstream attribution and AARM claims

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,238 +1,156 @@
 # MUTX Credits and Attributions
 
-MUTX is built on the shoulders of giants. This document acknowledges all open-source projects that MUTX incorporates, ports, or rebrand.
+MUTX is built on the shoulders of open-source projects. This document records
+the projects MUTX integrates with, materially adapts, or uses as an
+interoperability target. “Current upstream” means the release or commit checked
+on 2026-07-15; it is not a claim that MUTX has already migrated every integration
+to that revision.
 
----
+Machine-readable evidence, immutable source links, and local file scopes live in
+[`docs/legal/oss-attribution-evidence.json`](docs/legal/oss-attribution-evidence.json).
+Direct ports are recorded in
+[`docs/legal/oss-attribution-ledger.md`](docs/legal/oss-attribution-ledger.md).
 
-## Direct Feature Port Ledger
+## Integrated and adapted projects
 
-For direct code, schema, prompt, documentation, or UI reuse from external projects, MUTX keeps a per-port ledger in `docs/legal/oss-attribution-ledger.md`.
+### agent-run
 
-Current tracked upstreams for this process:
+- **Repository:** https://github.com/builderz-labs/agent-run
+- **License:** MIT — Copyright (c) 2026 Builderz Labs
+- **Current upstream:** no release tags; audited main commit
+  `9c7c3fa68413de878fae2d605c90fb334a0201f6`
+- **Upstream security status:** quarantined for MUTX dependency/vendor purposes
+  pending maintainer review of the current TypeScript entry point; do not import,
+  package, execute, or update from current upstream main
+- **MUTX use:** the MUTX observability schema materially adapts the agent-run
+  schema vocabulary into `MutxRun`, `MutxStep`, `MutxCost`, `MutxProvenance`,
+  and `MutxEval`.
 
-- Mission Control (`MIT`) - one direct dashboard-pattern reuse entry is recorded in the ledger
-- LACP (`MIT`) - no direct reuse entry is recorded yet
-- Guild AI (`Apache-2.0`) - no direct reuse entry is recorded yet
+Tracked local surfaces include `src/api/models/observability.py`,
+`src/api/models/observability_models.py`, `src/api/routes/observability.py`, and
+`sdk/mutx/observability.py`.
 
----
+MUTX carries its own adapted schemas and does not require the upstream
+TypeScript package at runtime. The current commit is recorded for audit evidence,
+not as a recommended upgrade target.
 
-## Core Dependencies
+### AARM documentation and specification
 
-### agent-run (Rebranded as MUTX Observability Schema)
+- **Repository:** https://github.com/aarm-dev/docs
+- **Repository license:** MIT — Copyright (c) 2023 Mintlify
+- **Current upstream:** audited main commit
+  `8eff208b98786b2c9a578b26cb7eaca440ec4020`
+- **MUTX use:** specification alignment and terminology for the runtime security
+  modules under `src/security/`.
 
-**Repository:** https://github.com/builderz-labs/agent-run
+The current specification defines **AARM Core** as R1–R6 and **AARM Extended**
+as R1–R9. The meanings of R1–R9 changed from the older model previously copied
+into MUTX. MUTX has relevant capabilities, but it has not demonstrated all
+technical tests or the organizational conditions required to call the product
+“AARM-conformant.” The evidence-based mapping is maintained in
+[`docs/legal/aarm-alignment.md`](docs/legal/aarm-alignment.md).
 
-**License:** MIT
+The MIT copyright in the AARM repository belongs to Mintlify; the former
+“Copyright (c) 2024 aarm-dev” notice was not present in the upstream license and
+has been removed.
 
-**Contribution:** Open standard for agent observability - MUTX Observability Schema is based on agent-run with renamed types:
+### Faramesh Core and FPL
 
-| agent-run Schema | MUTX Rename |
-|-----------------|-------------|
-| `AgentRun` | `MutxRun` |
-| `Step` | `MutxStep` |
-| `Cost` | `MutxCost` |
-| `Provenance` | `MutxProvenance` |
-| `EvalResult` | `MutxEval` |
+- **Core repository:** https://github.com/faramesh/faramesh-core
+- **FPL repository:** https://github.com/faramesh/fpl-lang
+- **Core current-main license:** Apache-2.0 at
+  `e230a9ac2d12d80ed6f632db42b6e1983ccbce82`
+- **Pinned installer release:** `v0.2.0`
+  (`ae3ebc9066d65e4e930164881c2f2ce2be554c7f`), licensed MPL-2.0
+- **Core latest semver tag:** `v1.2.9`
+  (`c85237e4e6b13745169291f60b9c6b985285dbaa`), licensed MPL-2.0 at that tag
+- **FPL current-main license:** Apache-2.0
+- **Current FPL audit ref:**
+  `b7aa0b7ad56f60428d692278a435c5e6640cec2b`
 
-The MUTX Observability layer (`src/api/models/observability.py`, `src/api/routes/observability.py`, `sdk/mutx/observability.py`) is derived from the agent-run specification.
+MUTX integrates with the Faramesh daemon and FPL policy format through
+`cli/faramesh_runtime.py`, `cli/commands/governance.py`, `cli/policies/*.fpl`,
+and `src/runtime/gateways/faramesh.py`. Faramesh is listed by AARM as
+**Aligned**, not **Conformant**; MUTX therefore does not use the integration as
+proof of AARM conformance.
 
-**MIT License Text:**
-```
-MIT License
+Neither audited current-main upstream contains a `NOTICE` file. The verbatim
+third-party Apache-2.0 text is retained at
+[`third_party/licenses/Apache-2.0.txt`](third_party/licenses/Apache-2.0.txt),
+and the verbatim MPL-2.0 text applying to the pinned Core `v0.2.0` release and
+historical `v1.2.9` tag is retained at
+[`third_party/licenses/MPL-2.0.txt`](third_party/licenses/MPL-2.0.txt). A
+Faramesh installation must be evaluated under the license at the exact ref being
+distributed; the main-branch relicense does not retroactively change either tag.
 
-Copyright (c) 2024 builderz-labs
+### Mission Control
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+- **Repository:** https://github.com/builderz-labs/mission-control
+- **License:** MIT — Copyright (c) 2026 Builderz Labs
+- **Current upstream release:** `v2.1.0`
+  (`b4ebc5418bea4fa9288a5c17fbddb9ba99740964`)
+- **MUTX use:** dashboard briefing and signal-display patterns.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
----
-
-### AARM - Autonomous Action Runtime Management
-
-**Repository:** https://github.com/aarm-dev/docs
-
-**License:** MIT
-
-**Contribution:** Runtime security specification - MUTX Security Layer implements AARM components:
-
-| AARM Component | MUTX Location | Description |
-|---------------|--------------|-------------|
-| Action Mediation Layer | `src/security/mediator.py` | Intercepts and normalizes tool invocations |
-| Context Accumulator | `src/security/context.py` | Tracks session state and intent |
-| Policy Engine | `src/security/policy.py` | Evaluates actions against policy |
-| Approval Service | `src/security/approvals.py` | Human-in-the-loop workflows |
-| Receipt Generator | `src/security/receipts.py` | Tamper-evident audit receipts |
-| Telemetry Exporter | `src/security/telemetry.py` | SIEM/SOAR integration |
-| Compliance Checker | `src/security/compliance.py` | AARM R1-R9 conformance verification |
-
-AARM defines what a runtime security system must do - MUTX implements it as the MUTX Security Layer.
-
-**MIT License Text:**
-```
-MIT License
-
-Copyright (c) 2024 aarm-dev
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Documentation"), to
-deal in the Documentation without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Documentation, and to permit persons to whom the
-Documentation is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Documentation.
-
-THE DOCUMENTATION IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE DOCUMENTATION OR THE USE OR OTHER DEALINGS IN
-THE DOCUMENTATION.
-```
-
----
-
-### Faramesh
-
-**Repository:** https://github.com/faramesh/faramesh-core
-
-**License:** MIT
-
-**Contribution:** Pre-execution governance engine - MUTX uses Faramesh as the AARM-compliant policy enforcement backend:
-
-- Deterministic FPL (Faramesh Policy Language) evaluation
-- Pre-execution blocking of tool calls
-- Human approval (DEFER) workflows
-- Credential broker for API key management
-- Cryptographic decision audit trail
-
-MUTX integration points:
-- `cli/faramesh_runtime.py` - Faramesh daemon management
-- `cli/commands/governance.py` - CLI governance commands
-- `cli/policies/*.fpl` - FPL policy files (starter, payment-bot, infra-bot, customer-support)
-- `src/runtime/gateways/faramesh.py` - Faramesh as AARM backend
-
-**MIT License Text:**
-```
-MIT License
-
-Copyright (c) 2024 faramesh
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
----
-
-### Mission Control (Inspiration and Direct Reuse)
-
-**Repository:** https://github.com/builderz-labs/mission-control
-
-**License:** MIT
-
-**Contribution:** Dashboard patterns and agent fleet management concepts, including tracked direct dashboard-pattern reuse.
-
-MUTX's operator surface and agent management patterns are inspired by Mission Control's approach to agent orchestration dashboards. Repo history also contains direct Mission Control pattern ports tracked in `docs/legal/oss-attribution-ledger.md`.
-
-**MIT License Text:**
-```
-MIT License
-
-Copyright (c) 2024 builderz-labs
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
----
+The direct adaptation is pinned to immutable upstream paths and the local port
+commit in the attribution ledger. The current upstream release is newer than
+that provenance pin; the two are intentionally reported separately.
 
 ### Orchestra Research AI-Research-SKILLs
 
-**Repository:** https://github.com/Orchestra-Research/AI-Research-SKILLs
+- **Repository:** https://github.com/Orchestra-Research/AI-Research-SKILLs
+- **License:** MIT — Copyright (c) 2025 Claude AI Research Skills Contributors
+- **Current upstream release:** `v1.7.2`
+  (`773a52944ba4747a18bd4ae9ade53fff041adcbc`)
+- **MUTX integration pin:**
+  `05f1958727bfc2bc22240f41d060504473c4f236`
 
-**License:** MIT
-
-**Contribution:** MUTX now ships a pinned integration against Orchestra Research's AI research skill library. The repo imports catalog metadata from upstream commit `05f1958727bfc2bc22240f41d060504473c4f236`, curates install bundles and swarm blueprints, and exposes a runtime sync path via `scripts/sync_orchestra_research_skills.py`.
-
-This is an integration and attribution layer, not a claim of authorship over the upstream skill content. The skill content remains credited to Orchestra Research and the upstream project authors they documented.
-
----
+MUTX imports catalog metadata, curates install bundles and swarm blueprints, and
+provides `scripts/sync_orchestra_research_skills.py`. The upstream skill content
+remains attributed to Orchestra Research and to the upstream authors documented
+in that repository. The difference between the current release and the MUTX pin
+is an explicit upgrade gap, not hidden drift.
 
 ### predict-rlm
 
-**Repository:** https://github.com/Trampoline-AI/predict-rlm
+- **Repository:** https://github.com/Trampoline-AI/predict-rlm
+- **License:** MIT — Copyright (c) 2026 Trampoline AI
+- **Current upstream release:** `v0.7.2`
+  (`4ff334dea79a2f27e96b7a50a358b0427050899e`)
+- **MUTX provenance pin:**
+  `5c7387afa1980b62b21a34ad0261256a95d8caa1`
 
-**License:** MIT
+MUTX uses predict-rlm as the document workflow engine and adapts its workflow
+families into MUTX job, artifact, worker, CLI, dashboard, and observability
+surfaces. The current upstream release and the historical adaptation pin are
+reported separately until compatibility with `v0.7.2` is validated.
 
-**Contribution:** MUTX uses `predict-rlm` as the document workflow engine for managed and local document analysis, contract comparison, invoice extraction, and document redaction. The MUTX document workflow surface intentionally aligns its template ids and output contracts with the upstream `predict-rlm` example families, while adding MUTX-specific job records, artifact storage, worker execution, and run/trace observability.
+## Candidate projects with no direct reuse recorded
 
-**Upstream ref used for attribution:** `Trampoline-AI/predict-rlm` @ `5c7387afa1980b62b21a34ad0261256a95d8caa1`
+### Guild AI
 
-Tracked local surface:
+- **Repository:** https://github.com/guildai/guildai
+- **License:** Apache-2.0
+- **Direct reuse:** none recorded
 
-- `src/api/services/document_engine.py` - `predict-rlm` execution adapter and readiness contract
-- `src/api/services/document_jobs.py` - document job lifecycle and run/trace linkage
-- `src/api/routes/documents.py` - `/v1/documents/*` API surface
-- `src/api/document_worker.py` - managed execution worker loop
-- `cli/commands/documents.py` and `cli/services/documents.py` - CLI operator path
-- `app/dashboard/documents/page.tsx` and `components/dashboard/DocumentsPageClient.tsx` - dashboard operator path
-- `docs/document-workflows.md` - operator-facing documentation and runtime contract
+Guild AI remains a candidate source. If code or documentation is ported later,
+the exact upstream commit, local scope, Apache-2.0 license, and any upstream
+`NOTICE` material must be recorded in the ledger in the same change.
 
-MUTX does not claim authorship over `predict-rlm`, its examples, or Trampoline AI's upstream design work. Upstream attribution for the adapted workflow surface is also tracked in `docs/legal/oss-attribution-ledger.md`.
+### LACP
 
-**MIT License Text:**
-```
+“LACP” is not a sufficient project identity: the repository owner, canonical URL,
+and license have not been established. MUTX records no direct reuse from LACP and
+makes **no license claim** for it. No LACP port may land until those facts are
+resolved and pinned.
+
+## License texts and immutable evidence
+
+The exact upstream license files audited for this record are pinned in the
+machine-readable evidence file. MIT-licensed adaptations retain the following
+permission text together with each project’s copyright notice above:
+
+```text
 MIT License
-
-Copyright (c) 2026 Trampoline AI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -253,22 +171,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
----
+Third-party Apache-2.0 text:
+[`third_party/licenses/Apache-2.0.txt`](third_party/licenses/Apache-2.0.txt).
+MPL-2.0 text:
+[`third_party/licenses/MPL-2.0.txt`](third_party/licenses/MPL-2.0.txt).
 
-## Full License Texts
+## Independence and trademarks
 
-The incorporated projects listed above currently use the MIT License. See their repositories for full license texts:
-
-- agent-run: https://github.com/builderz-labs/agent-run/blob/main/LICENSE
-- AARM: https://github.com/aarm-dev/docs/blob/main/LICENSE.txt
-- Faramesh: https://github.com/faramesh/faramesh-core/blob/main/LICENSE
-- Mission Control: https://github.com/builderz-labs/mission-control/blob/main/LICENSE
-- predict-rlm: https://github.com/Trampoline-AI/predict-rlm/blob/main/LICENSE
-
----
-
-## Trademark Attribution
-
-MUTX, agent-run, AARM, Faramesh, and Mission Control are separate projects.
-MUTX is not affiliated with, endorsed by, or connected to any of these projects
-beyond the open-source license grants described above.
+MUTX, agent-run, AARM, Faramesh, Mission Control, Orchestra Research,
+predict-rlm, and Guild AI are separate projects. MUTX is not affiliated with or
+endorsed by these projects beyond the license grants and integrations described
+above. Project names and marks remain the property of their respective owners.

--- a/LICENSE-FAQ.md
+++ b/LICENSE-FAQ.md
@@ -65,9 +65,18 @@ No. The license does not grant trademark rights. See `TRADEMARKS.md`.
 
 ## What about the third-party code in the repo?
 
-MUTX incorporates MIT-licensed projects (agent-run, AARM, Faramesh, Mission Control). Those remain under their original licenses per their original terms. See `CREDITS.md` for full attribution.
+MUTX includes or adapts work under multiple third-party licenses. agent-run,
+the AARM documentation, Mission Control, Orchestra Research AI-Research-SKILLs,
+and predict-rlm use MIT licenses at the audited refs. Faramesh Core current main,
+FPL current main, and Guild AI use Apache-2.0; the pinned Faramesh Core `v0.2.0`
+release and historical `v1.2.9` tag carry MPL-2.0. Those projects remain
+governed by the license at the exact distributed ref; see `CREDITS.md` for refs,
+copyright notices, and license evidence.
 
-For direct feature ports from Mission Control (MIT), LACP (MIT), and Guild AI (Apache-2.0), MUTX also keeps `docs/legal/oss-attribution-ledger.md` so the upstream source, license, and local file scope stay visible.
+Direct adaptations are recorded in `docs/legal/oss-attribution-ledger.md` and
+the machine-readable `docs/legal/oss-attribution-evidence.json`. “LACP” remains
+an unresolved project identity, so MUTX records no reuse and makes no license
+claim for it.
 
 ## Who do I contact for commercial licensing?
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -74,6 +74,8 @@
 * [Contributing](contributing/README.md)
 * [Security Policy](security.md)
 * [Licensing](docs/legal/index.md)
+  * [OSS Attribution Ledger](docs/legal/oss-attribution-ledger.md)
+  * [AARM Alignment Status](docs/legal/aarm-alignment.md)
 * [Contributor Covenant Code of Conduct](code_of_conduct.md)
 * [AGENTS.md](AGENTS.md)
 * [App Dashboard](docs/app-dashboard.md)

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -2098,7 +2098,7 @@ export interface paths {
         };
         /**
          * Run Compliance Check
-         * @description Run AARM conformance checks.
+         * @description Run local capability checks mapped to AARM; not a conformance report.
          */
         get: operations["run_compliance_check_v1_security_compliance_get"];
         put?: never;
@@ -5245,7 +5245,7 @@ export interface components {
         };
         /**
          * ComplianceResponse
-         * @description AARM compliance check response.
+         * @description Backward-compatible local AARM-alignment check response.
          */
         ComplianceResponse: {
             /** Overall Satisfied */

--- a/cli/commands/observability.py
+++ b/cli/commands/observability.py
@@ -11,8 +11,11 @@ Commands:
 Based on the agent-run open standard for agent observability.
 https://github.com/builderz-labs/agent-run
 
-MIT License - Copyright (c) 2024 builderz-labs
-https://github.com/builderz-labs/agent-run/blob/main/LICENSE
+MIT License - Copyright (c) 2026 Builderz Labs
+https://github.com/builderz-labs/agent-run/blob/9c7c3fa68413de878fae2d605c90fb334a0201f6/LICENSE
+
+Schema adaptation only. Do not import or execute the current upstream package;
+it is quarantined pending maintainer security review.
 """
 
 import json

--- a/cli/commands/security.py
+++ b/cli/commands/security.py
@@ -1,21 +1,21 @@
 """
 MUTX Security CLI Commands.
 
-CLI commands for MUTX Security Layer - AARM-compliant runtime security.
+CLI commands for MUTX runtime-security capabilities.
 
 Commands:
 - mutx security evaluate <tool> <args>   - Dry-run policy evaluation
 - mutx security approve <token>          - Approve deferred action
 - mutx security deny <token>             - Deny deferred action
-- mutx security audit                   - Run AARM compliance check
+- mutx security audit                   - Run local AARM-alignment gap check
 - mutx security receipts                 - View recent receipts
 - mutx security metrics                 - View governance metrics
 
-Based on the AARM (Autonomous Action Runtime Management) specification.
-https://github.com/aarm-dev/docs
+Informed by the AARM specification. The local audit is not an AARM conformance
+report and does not establish Core, Extended, or organizational conformance.
+https://github.com/aarm-dev/docs/tree/8eff208b98786b2c9a578b26cb7eaca440ec4020
 
-MIT License - Copyright (c) 2024 aarm-dev
-https://github.com/aarm-dev/docs/blob/main/LICENSE.txt
+AARM documentation reference: MIT License, Copyright (c) 2023 Mintlify.
 """
 
 import json
@@ -37,7 +37,7 @@ def _get_client_instance():
 
 @click.group(name="security")
 def security_group():
-    """MUTX Security - AARM-compliant runtime security for AI agents."""
+    """MUTX runtime-security capabilities and local alignment checks."""
     pass
 
 
@@ -223,9 +223,9 @@ def deny_action(token: str, reviewer: str, reason: str, output_json: bool):
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 def run_audit(output_json: bool):
     """
-    Run AARM conformance checks.
+    Run the local AARM-alignment gap check.
 
-    Verifies that MUTX Security Layer satisfies all 9 AARM requirements.
+    Reports current capability gaps. This is not an AARM conformance assessment.
     """
     client = _get_client_instance()
 
@@ -234,7 +234,7 @@ def run_audit(output_json: bool):
         response.raise_for_status()
         report = response.json()
     except Exception as exc:
-        click.echo(f"Error running compliance check: {exc}", err=True)
+        click.echo(f"Error running alignment check: {exc}", err=True)
         return
 
     if output_json:
@@ -245,9 +245,10 @@ def run_audit(output_json: bool):
     summary = report.get("summary", {})
 
     if overall:
-        click.echo("\033[92m✓ AARM Compliance: PASSED\033[0m")
+        click.echo("\033[92m✓ Local AARM alignment checks: COMPLETE\033[0m")
+        click.echo("This is not an AARM conformance designation.")
     else:
-        click.echo("\033[91m✗ AARM Compliance: FAILED\033[0m")
+        click.echo("\033[93m! Local AARM alignment checks: GAPS REMAIN\033[0m")
 
     click.echo("")
     click.echo("Summary:")

--- a/cli/faramesh_runtime.py
+++ b/cli/faramesh_runtime.py
@@ -13,7 +13,11 @@ from pathlib import Path
 
 FAREMESH_PROVIDER_ID = "faramesh"
 FAREMESH_DEFAULT_DAEMON_PORT = 7777
-FAREMESH_INSTALL_URL = "https://raw.githubusercontent.com/faramesh/faramesh-core/main/install.sh"
+FAREMESH_INSTALL_REF = "ae3ebc9066d65e4e930164881c2f2ce2be554c7f"
+FAREMESH_INSTALL_VERSION = "0.2.0"
+FAREMESH_INSTALL_URL = (
+    f"https://raw.githubusercontent.com/faramesh/faramesh-core/{FAREMESH_INSTALL_REF}/install.sh"
+)
 
 
 def _default_faramesh_socket_path() -> str:
@@ -259,6 +263,8 @@ def ensure_faramesh_installed(
 
             cmd = [
                 str(install_script_path),
+                "--version",
+                FAREMESH_INSTALL_VERSION,
                 "--install-dir",
                 str(Path.home() / ".local" / "bin"),
             ]

--- a/cli/services/observability.py
+++ b/cli/services/observability.py
@@ -2,7 +2,7 @@
 Observability and Security API service for CLI and TUI.
 
 Provides access to MUTX Observability Schema (MutxRun, MutxStep, etc.)
-and AARM Security Layer (evaluations, approvals, receipts, compliance).
+and AARM-alignment security capabilities (evaluations, approvals, receipts, gap checks).
 """
 
 from __future__ import annotations
@@ -91,7 +91,7 @@ class ObservabilityService(APIService):
 
 
 class SecurityService(APIService):
-    """Service for MUTX AARM Security API."""
+    """Service for MUTX runtime-security and AARM-alignment API."""
 
     def evaluate_action(
         self,
@@ -112,7 +112,7 @@ class SecurityService(APIService):
         return response.json()
 
     def get_compliance_report(self) -> dict[str, Any]:
-        """Run AARM conformance checks."""
+        """Run the local AARM-alignment gap check (not conformance)."""
         response = self._request("GET", "/v1/security/compliance")
         self._expect_status(response, {200})
         return response.json()

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -8519,7 +8519,7 @@
           "security"
         ],
         "summary": "Run Compliance Check",
-        "description": "Run AARM conformance checks.",
+        "description": "Run local capability checks mapped to AARM; not a conformance report.",
         "operationId": "run_compliance_check_v1_security_compliance_get",
         "parameters": [
           {
@@ -18055,7 +18055,7 @@
           "results"
         ],
         "title": "ComplianceResponse",
-        "description": "AARM compliance check response."
+        "description": "Backward-compatible local AARM-alignment check response."
       },
       "CostSummaryResponse": {
         "properties": {

--- a/docs/gtm/competitive_notes.md
+++ b/docs/gtm/competitive_notes.md
@@ -20,11 +20,11 @@ These are **adjacent, not identical**. AGT is SDK-first (developer tooling). MUT
 | Capability | MUTX | AGT v3.1.0 | MUTX Advantage |
 |-----------|------|------------|----------------|
 | Policy engine | ✅ PolicyEngine + REST API | ✅ <0.1ms eval | Parity |
-| Action interception | ✅ ActionMediator (R1,R2) | ✅ Pre-execution gate | Parity |
-| Approval workflows | ✅ Built-in (R5) | ⚠️ Delegates to custom code | **MUTX ahead** |
-| Audit receipts | ✅ Crypto-signed (R6) | ✅ Audit trails | Parity |
+| Action interception | ⚠️ Partial current AARM R1/R3; universal path coverage not demonstrated | ✅ Pre-execution gate | Unverified |
+| Approval workflows | ⚠️ Built-in flow; current AARM R4 STEP_UP/DEFER distinction incomplete | ⚠️ Delegates to custom code | Unverified |
+| Audit receipts | ⚠️ Optional signing; complete current AARM R5 evidence not demonstrated | ✅ Audit trails | AGT evidence stronger |
 | Credential brokering | ✅ 6 backends + TTL | ❌ None | **MUTX ahead** |
-| Context-aware eval | ✅ Session + intent (R3,R4) | ⚠️ Partial | **MUTX ahead** |
+| Context-aware eval | ⚠️ Session context plus heuristic intent signal; current AARM R2/R3/R7 incomplete | ⚠️ Partial | Unverified |
 | Runtime supervision | ✅ Faramesh 13-framework | ❌ SDK-level only | **MUTX ahead** |
 | OWASP ASI 2026 | ❌ No mapping | ✅ 10/10 | AGT ahead |
 | Shadow AI discovery | ❌ None | ✅ agent-discovery | AGT ahead |
@@ -43,10 +43,12 @@ These are **adjacent, not identical**. AGT is SDK-first (developer tooling). MUT
 ### Lead with (MUTX-only strengths)
 1. **Credential brokering** — "The only agent governance platform with built-in secret management across 6 backends"
 2. **Runtime supervision** — "Govern agents at runtime, not just at build time — Faramesh auto-patches 13 frameworks"
-3. **AARM compliance** — "Formal AARM conformance (R1-R9) with automated compliance reporting"
+3. **Evidence-based AARM alignment** — publish the current R1-R9 gap map and
+   close every Core verification before considering a conformance claim
 4. **In-product approvals** — "Human-in-the-loop approvals built into the platform, not bolted on"
 
 ### Don't claim until built
+- AARM Core or Extended conformance (technical and organizational evidence is incomplete)
 - OWASP Agentic Top 10 coverage (need mapping doc)
 - Multi-language SDK (TypeScript priority)
 - Shadow AI discovery
@@ -76,7 +78,8 @@ This means AGT is not a direct revenue competitor — it's a mindshare competito
 
 ### 2026-04-20
 - AGT stable at v3.1.0 (no new releases since April 11)
-- MUTX major advances: full AARM security layer, credential broker, Faramesh supervision
+- Historical note corrected: MUTX expanded AARM-informed capability modules,
+  credential-broker surfaces, and Faramesh supervision; “full” was not verified
 - Gap reduction: 6 capabilities moved from Large to Small/None
 - New gaps: quantum-safe crypto, prompt injection evaluator (from AGT v3.1.0)
 - MUTX now has 4 capabilities where it leads AGT (was 0 at initial audit)

--- a/docs/legal/aarm-alignment.md
+++ b/docs/legal/aarm-alignment.md
@@ -1,0 +1,59 @@
+---
+description: Evidence-based mapping from the current AARM requirements to MUTX capabilities and gaps.
+---
+
+# AARM alignment status
+
+MUTX is **not claiming AARM Core or AARM Extended conformance**. This page is a
+local engineering gap assessment against the AARM requirements audited at
+`aarm-dev/docs@8eff208b98786b2c9a578b26cb7eaca440ec4020` on 2026-07-15.
+
+The authoritative requirements are
+[`conformance/requirements.mdx`](https://github.com/aarm-dev/docs/blob/8eff208b98786b2c9a578b26cb7eaca440ec4020/conformance/requirements.mdx)
+and the authoritative testing protocol is
+[`conformance/testing.mdx`](https://github.com/aarm-dev/docs/blob/8eff208b98786b2c9a578b26cb7eaca440ec4020/conformance/testing.mdx).
+AARM Core requires every MUST requirement, R1–R6. AARM Extended adds R7–R9.
+
+## Technical mapping
+
+“Partial” means relevant code exists, not that the upstream verification has
+passed. Every row remains **not demonstrated** until its full upstream test set
+has reproducible evidence for the production execution path.
+
+| ID | Current AARM requirement | Relevant MUTX evidence | Gap to close | Status |
+| --- | --- | --- | --- | --- |
+| R1 | Pre-execution interception that blocks or defers, has no target effects, and fails closed | `src/security/mediator.py`, `src/security/policy.py`, `src/runtime/gateways/faramesh.py` | Prove every supported execution path is intercepted, denied/deferred actions have no effects, unavailability cannot fail open, and both decisions generate receipts | Partial; not demonstrated |
+| R2 | Accumulate prior actions, data classifications, original request, and make context available to policy evaluation | `src/security/context.py` tracks actions, data access, and original request | Add classification rules with a highest-sensitivity default; prove the production policy path consumes the full context; add tamper-evident context storage if claiming the SHOULD | Partial; not demonstrated |
+| R3 | Static and contextual policy evaluation with four action classifications, parameter validation, and mandatory deferral conditions | `src/security/mediator.py` validates registered tool schemas; `src/security/policy.py` supports static rules and an intent signal | Add `context-dependent defer`; defer on missing context, equal-priority conflicts, and low confidence; document/audit those conditions; prove all parameter constraint classes | Partial; not demonstrated |
+| R4 | Five distinct decisions: ALLOW, DENY, MODIFY, STEP_UP, and DEFER, including safe timeout and dependency behavior | `PolicyDecision` supports ALLOW, DENY, MODIFY, DEFER; `ApprovalService` provides a human decision flow | Add a distinct STEP_UP decision; keep DEFER separate from human approval; enforce deny-on-timeout, dependency propagation, ordering, and bounded cascading deferrals | Partial; not demonstrated |
+| R5 | Signed, offline-verifiable receipts for every decision with full action, context, identity, decision, approval/deferral, outcome, and policy evidence | `src/security/receipts.py` can generate receipts and sign with Ed25519 when `cryptography` is present | Make signing mandatory; remove the non-public-key HMAC fallback from any conformance path; include every required identity, role, policy hash/version, deferral, approval, and resolution field; prove tamper tests for every decision | Partial; not demonstrated |
+| R6 | Bind human, service, agent, session, role, and privilege scope to trusted, fresh, revocation-aware identity | `NormalizedAction` carries user, agent, and session identifiers; API auth validates a caller | Add service identity and role/privilege scope to actions and receipts; prove trusted-source validation, freshness, revocation, rejection/flagging of unverifiable identity, and preservation across deferral/delegation | Partial; not demonstrated |
+| R7 | Semantic-distance tracking from stated intent with calibrated cumulative drift and escalation | `ContextAccumulator.evaluate_intent()` computes a denial/error/repetition heuristic | Implement and calibrate semantic distance against the original request, track cumulative drift, document aggregation and thresholds, and prove alert/deferral/escalation behavior | Gap; not demonstrated |
+| R8 | Structured near-real-time telemetry with filtering, DEFER coverage, and historical batch export | `src/security/telemetry.py` emits custom structured events and Prometheus metrics | Prove seconds-level delivery, decision/identity/action filtering, complete DEFER events, documented schema stability, and historical batch export to a security platform | Partial; not demonstrated |
+| R9 | Just-in-time, operation-scoped credentials with audit logging | Faramesh exposes a credential-broker integration surface; MUTX has no equivalent native credential issuance proof | Integrate and test short-lived operation-scoped credentials, including a read credential that cannot write, and record usage in receipts/telemetry | Gap; not demonstrated |
+
+## Organizational conditions
+
+The AARM documentation also asks an organization using the “AARM-conformant”
+designation to demonstrate community engagement, an actively used production
+deployment, a relevant recognized security certification, and participation in
+future benchmarking. This repository does not contain sufficient public evidence
+for those conditions. They are therefore **not demonstrated** and cannot be
+inferred from unit tests or from this mapping.
+
+## What the API self-check means
+
+`GET /v1/security/compliance` and `AARMComplianceChecker` are retained for
+backward compatibility. They are local capability checks, not an AARM validation
+report. A true conformance statement requires the current upstream technical
+tests plus the organizational evidence described above.
+
+## Updating this assessment
+
+1. Pin the new AARM commit in
+   `docs/legal/oss-attribution-evidence.json` before changing requirement names.
+2. Update every source header that references a requirement number.
+3. Add production-path tests matching the upstream verification language.
+4. Keep a row “not demonstrated” until the complete test and evidence set exists.
+5. Do not use “AARM-conformant” in product or marketing copy without an approved,
+   current conformance record.

--- a/docs/legal/index.md
+++ b/docs/legal/index.md
@@ -46,18 +46,30 @@ See [LICENSE-FAQ](https://raw.githubusercontent.com/mutx-dev/mutx-dev/main/LICEN
 
 ## Third-Party Code
 
-MUTX incorporates MIT-licensed components:
+MUTX includes integrations, specification alignment, and material adaptations
+from projects under more than one license:
 
-- **agent-run** (builderz-labs) — Observability schema
-- **AARM** (aarm-dev) — Security layer specification
-- **Faramesh** (Faramesh Technologies) — Governance engine
-- **Mission Control** (builderz-labs) — Dashboard inspiration and tracked direct dashboard-pattern reuse
-- **Orchestra Research AI-Research-SKILLs** — Imported skill catalog metadata, curated bundles, and runtime sync path for research/operator workflows
-- **predict-rlm** (Trampoline AI) — Document workflow engine integration plus adapted template contracts and operator docs aligned to the upstream document analysis, contract comparison, invoice processing, and document redaction examples
+| Project | Audited license | Relationship |
+| --- | --- | --- |
+| agent-run | MIT | Observability schema adaptation; current upstream is quarantined for dependency/vendor use pending security review |
+| AARM documentation | MIT (Copyright (c) 2023 Mintlify) | Runtime-security specification alignment; no Core or Extended conformance claim |
+| Faramesh Core and FPL | Core main: Apache-2.0; pinned Core `v0.2.0` and historical `v1.2.9`: MPL-2.0; FPL main: Apache-2.0 | Governance daemon and policy-format integration; installer and license follow exact refs |
+| Mission Control | MIT | Tracked dashboard briefing-pattern adaptation |
+| Orchestra Research AI-Research-SKILLs | MIT | Pinned catalog, bundles, and sync integration |
+| predict-rlm | MIT | Document-engine integration and workflow adaptation |
+| Guild AI | Apache-2.0 | Candidate only; no direct reuse recorded |
+| LACP | Unresolved | No canonical repository or license established; no reuse recorded |
 
-All third-party code remains under its original license. See [CREDITS.md](https://raw.githubusercontent.com/mutx-dev/mutx-dev/main/CREDITS.md) for full attribution and license texts.
+All third-party work remains under its original license. See
+[CREDITS.md](https://raw.githubusercontent.com/mutx-dev/mutx-dev/main/CREDITS.md)
+for attribution and the
+[machine-readable evidence](https://raw.githubusercontent.com/mutx-dev/mutx-dev/main/docs/legal/oss-attribution-evidence.json) for immutable refs,
+license links, and validated local paths.
 
-Direct feature ports and materially adapted upstream workflow surfaces from Mission Control (MIT), LACP (MIT), Guild AI (Apache-2.0), and predict-rlm (MIT) are tracked in the [OSS Attribution Ledger](oss-attribution-ledger.md). The ledger records the upstream source, local MUTX scope, and whether the reuse was direct or still pending.
+Direct adaptations are tracked in the
+[OSS Attribution Ledger](oss-attribution-ledger.md). The current AARM
+requirement mapping and the gaps that prevent a conformance claim are documented
+in [AARM Alignment Status](aarm-alignment.md).
 
 ## Trademark Policy
 

--- a/docs/legal/oss-attribution-evidence.json
+++ b/docs/legal/oss-attribution-evidence.json
@@ -1,0 +1,187 @@
+{
+  "schema_version": 1,
+  "verified_at": "2026-07-15",
+  "projects": [
+    {
+      "id": "agent-run",
+      "name": "agent-run",
+      "status": "adapted-upstream-quarantined",
+      "repository": "https://github.com/builderz-labs/agent-run",
+      "license": "MIT",
+      "copyright": "Copyright (c) 2026 Builderz Labs",
+      "current_ref": "9c7c3fa68413de878fae2d605c90fb334a0201f6",
+      "current_version": null,
+      "release_url": "https://github.com/builderz-labs/agent-run/commit/9c7c3fa68413de878fae2d605c90fb334a0201f6",
+      "license_url": "https://github.com/builderz-labs/agent-run/blob/9c7c3fa68413de878fae2d605c90fb334a0201f6/LICENSE",
+      "security_review_url": "https://github.com/builderz-labs/agent-run/blob/9c7c3fa68413de878fae2d605c90fb334a0201f6/typescript/src/index.ts",
+      "security_status": "quarantined-do-not-import-package-execute-or-update-pending-maintainer-review",
+      "local_paths": [
+        "src/api/models/observability.py",
+        "src/api/models/observability_models.py",
+        "src/api/routes/observability.py",
+        "sdk/mutx/observability.py"
+      ]
+    },
+    {
+      "id": "aarm-docs",
+      "name": "AARM documentation",
+      "status": "specification-alignment",
+      "repository": "https://github.com/aarm-dev/docs",
+      "license": "MIT",
+      "copyright": "Copyright (c) 2023 Mintlify",
+      "current_ref": "8eff208b98786b2c9a578b26cb7eaca440ec4020",
+      "current_version": null,
+      "release_url": "https://github.com/aarm-dev/docs/commit/8eff208b98786b2c9a578b26cb7eaca440ec4020",
+      "license_url": "https://github.com/aarm-dev/docs/blob/8eff208b98786b2c9a578b26cb7eaca440ec4020/LICENSE.txt",
+      "requirements_url": "https://github.com/aarm-dev/docs/blob/8eff208b98786b2c9a578b26cb7eaca440ec4020/conformance/requirements.mdx",
+      "local_paths": [
+        "src/security/mediator.py",
+        "src/security/context.py",
+        "src/security/policy.py",
+        "src/security/approvals.py",
+        "src/security/receipts.py",
+        "src/security/telemetry.py",
+        "src/security/compliance.py",
+        "docs/legal/aarm-alignment.md"
+      ]
+    },
+    {
+      "id": "faramesh-core",
+      "name": "Faramesh Core",
+      "status": "integrated",
+      "repository": "https://github.com/faramesh/faramesh-core",
+      "license": "Apache-2.0",
+      "copyright": null,
+      "current_ref": "e230a9ac2d12d80ed6f632db42b6e1983ccbce82",
+      "current_version": null,
+      "release_url": "https://github.com/faramesh/faramesh-core/commit/e230a9ac2d12d80ed6f632db42b6e1983ccbce82",
+      "license_url": "https://github.com/faramesh/faramesh-core/blob/e230a9ac2d12d80ed6f632db42b6e1983ccbce82/LICENSE",
+      "latest_semver_tag": "v1.2.9",
+      "latest_semver_tag_ref": "c85237e4e6b13745169291f60b9c6b985285dbaa",
+      "latest_semver_tag_url": "https://github.com/faramesh/faramesh-core/tree/c85237e4e6b13745169291f60b9c6b985285dbaa",
+      "latest_semver_tag_license": "MPL-2.0",
+      "latest_semver_tag_license_url": "https://github.com/faramesh/faramesh-core/blob/c85237e4e6b13745169291f60b9c6b985285dbaa/LICENSE",
+      "installer_ref": "ae3ebc9066d65e4e930164881c2f2ce2be554c7f",
+      "installer_version": "v0.2.0",
+      "installer_release_url": "https://github.com/faramesh/faramesh-core/releases/tag/v0.2.0",
+      "installer_source_url": "https://github.com/faramesh/faramesh-core/blob/ae3ebc9066d65e4e930164881c2f2ce2be554c7f/install.sh",
+      "installer_license": "MPL-2.0",
+      "installer_license_url": "https://github.com/faramesh/faramesh-core/blob/ae3ebc9066d65e4e930164881c2f2ce2be554c7f/LICENSE",
+      "notice_url": null,
+      "local_paths": [
+        "cli/faramesh_runtime.py",
+        "cli/commands/governance.py",
+        "src/runtime/gateways/faramesh.py",
+        "third_party/licenses/Apache-2.0.txt",
+        "third_party/licenses/MPL-2.0.txt"
+      ]
+    },
+    {
+      "id": "fpl-lang",
+      "name": "Faramesh Policy Language",
+      "status": "format-integration",
+      "repository": "https://github.com/faramesh/fpl-lang",
+      "license": "Apache-2.0",
+      "copyright": null,
+      "current_ref": "b7aa0b7ad56f60428d692278a435c5e6640cec2b",
+      "current_version": null,
+      "release_url": "https://github.com/faramesh/fpl-lang/commit/b7aa0b7ad56f60428d692278a435c5e6640cec2b",
+      "license_url": "https://github.com/faramesh/fpl-lang/blob/b7aa0b7ad56f60428d692278a435c5e6640cec2b/LICENSE",
+      "notice_url": null,
+      "local_paths": [
+        "cli/policies",
+        "third_party/licenses/Apache-2.0.txt"
+      ]
+    },
+    {
+      "id": "mission-control",
+      "name": "Mission Control",
+      "status": "adapted",
+      "repository": "https://github.com/builderz-labs/mission-control",
+      "license": "MIT",
+      "copyright": "Copyright (c) 2026 Builderz Labs",
+      "current_ref": "b4ebc5418bea4fa9288a5c17fbddb9ba99740964",
+      "current_version": "v2.1.0",
+      "release_url": "https://github.com/builderz-labs/mission-control/commit/b4ebc5418bea4fa9288a5c17fbddb9ba99740964",
+      "license_url": "https://github.com/builderz-labs/mission-control/blob/b4ebc5418bea4fa9288a5c17fbddb9ba99740964/LICENSE",
+      "provenance_ref": "eb7c35e950b83f73d6fd61e89f7d4b377db2ad50",
+      "source_urls": [
+        "https://github.com/builderz-labs/mission-control/blob/eb7c35e950b83f73d6fd61e89f7d4b377db2ad50/src/components/dashboard/widgets/briefing-bar-widget.tsx",
+        "https://github.com/builderz-labs/mission-control/blob/eb7c35e950b83f73d6fd61e89f7d4b377db2ad50/src/components/dashboard/widget-primitives.tsx"
+      ],
+      "local_port_commit": "972ab49b0af83d15042b2301679246103cbdbab6",
+      "local_paths": [
+        "components/dashboard/DashboardOverviewPageClient.tsx",
+        "components/dashboard/livePrimitives.tsx"
+      ]
+    },
+    {
+      "id": "orchestra-research",
+      "name": "Orchestra Research AI-Research-SKILLs",
+      "status": "integrated-behind-upstream",
+      "repository": "https://github.com/Orchestra-Research/AI-Research-SKILLs",
+      "license": "MIT",
+      "copyright": "Copyright (c) 2025 Claude AI Research Skills Contributors",
+      "current_ref": "773a52944ba4747a18bd4ae9ade53fff041adcbc",
+      "current_version": "v1.7.2",
+      "release_url": "https://github.com/Orchestra-Research/AI-Research-SKILLs/commit/773a52944ba4747a18bd4ae9ade53fff041adcbc",
+      "license_url": "https://github.com/Orchestra-Research/AI-Research-SKILLs/blob/773a52944ba4747a18bd4ae9ade53fff041adcbc/LICENSE",
+      "integration_ref": "05f1958727bfc2bc22240f41d060504473c4f236",
+      "local_paths": [
+        "scripts/sync_orchestra_research_skills.py",
+        "src/api/data/orchestra_research_catalog.json",
+        "docs/orchestra-research.md"
+      ]
+    },
+    {
+      "id": "predict-rlm",
+      "name": "predict-rlm",
+      "status": "adapted-behind-upstream",
+      "repository": "https://github.com/Trampoline-AI/predict-rlm",
+      "license": "MIT",
+      "copyright": "Copyright (c) 2026 Trampoline AI",
+      "current_ref": "4ff334dea79a2f27e96b7a50a358b0427050899e",
+      "current_version": "v0.7.2",
+      "release_url": "https://github.com/Trampoline-AI/predict-rlm/commit/4ff334dea79a2f27e96b7a50a358b0427050899e",
+      "license_url": "https://github.com/Trampoline-AI/predict-rlm/blob/4ff334dea79a2f27e96b7a50a358b0427050899e/LICENSE",
+      "integration_ref": "5c7387afa1980b62b21a34ad0261256a95d8caa1",
+      "local_paths": [
+        "src/api/services/document_engine.py",
+        "src/api/services/document_jobs.py",
+        "src/api/routes/documents.py",
+        "src/api/document_worker.py",
+        "cli/commands/documents.py",
+        "cli/services/documents.py",
+        "app/dashboard/documents/page.tsx",
+        "components/dashboard/DocumentsPageClient.tsx",
+        "docs/document-workflows.md"
+      ]
+    },
+    {
+      "id": "guild-ai",
+      "name": "Guild AI",
+      "status": "candidate-no-reuse",
+      "repository": "https://github.com/guildai/guildai",
+      "license": "Apache-2.0",
+      "copyright": null,
+      "current_ref": "dfbefedb6ca5ce3a1341f9f00a4016420f6fc76d",
+      "current_version": "0.9.0",
+      "release_url": "https://github.com/guildai/guildai/commit/dfbefedb6ca5ce3a1341f9f00a4016420f6fc76d",
+      "license_url": "https://github.com/guildai/guildai/blob/dfbefedb6ca5ce3a1341f9f00a4016420f6fc76d/LICENSE.txt",
+      "local_paths": []
+    },
+    {
+      "id": "lacp",
+      "name": "LACP (unresolved)",
+      "status": "unresolved-no-reuse",
+      "repository": null,
+      "license": null,
+      "copyright": null,
+      "current_ref": null,
+      "current_version": null,
+      "release_url": null,
+      "license_url": null,
+      "local_paths": []
+    }
+  ]
+}

--- a/docs/legal/oss-attribution-ledger.md
+++ b/docs/legal/oss-attribution-ledger.md
@@ -1,35 +1,46 @@
 ---
-description: Ledger and process for direct open-source feature ports into MUTX.
+description: Provenance ledger and process for direct open-source adaptations in MUTX.
 ---
 
-# OSS Attribution Ledger
+# OSS attribution ledger
 
-This ledger exists for direct reuse from external projects. The goal is to keep provenance obvious when code, schemas, prompts, docs, or UI flows are ported or materially adapted into MUTX.
+This ledger records direct or material reuse of external code, schemas,
+documentation, prompts, or UI structures. Loose inspiration belongs in design
+documentation instead. Immutable links, audited upstream versions, license
+facts, and machine-validated local paths are maintained in
+[`oss-attribution-evidence.json`](https://raw.githubusercontent.com/mutx-dev/mutx-dev/main/docs/legal/oss-attribution-evidence.json).
 
-Use this ledger for direct reuse from:
+## Required process
 
-- Mission Control (`MIT`)
-- LACP (`MIT`)
-- Guild AI (`Apache-2.0`)
-- predict-rlm (`MIT`)
+When a direct adaptation lands:
 
-Do not use this ledger for loose inspiration. If MUTX only borrows an idea, product direction, or naming pattern, document that elsewhere instead of calling it a port.
+1. Update the project in `CREDITS.md`.
+2. Add or update its evidence object in
+   `docs/legal/oss-attribution-evidence.json` with immutable source and license
+   URLs, an exact upstream ref, and every affected local path.
+3. Append a row here with the evidence ID and the local port commit.
+4. Preserve all copyright and license notices required by the upstream license.
+5. For Apache-2.0 sources, retain the Apache-2.0 text and any upstream `NOTICE`
+   material in the distribution. Record explicitly when the audited ref has no
+   `NOTICE` file.
+6. For MPL-2.0 sources, retain the MPL-2.0 text and satisfy file-level source and
+   modification-notice obligations for any Covered Software that is distributed.
+7. Keep provenance and code in the same pull request whenever possible.
 
-## Required Process
+## Recorded adaptations
 
-When a direct port lands:
+| Ledger ID | Date | Evidence ID | Upstream provenance | MUTX scope | Reuse mode | Local port commit |
+| --- | --- | --- | --- | --- | --- | --- |
+| `agent-run-2026-03-25-01` | 2026-03-25 | `agent-run` | Schema family under [`builderz-labs/agent-run@9c7c3fa`](https://github.com/builderz-labs/agent-run/tree/9c7c3fa68413de878fae2d605c90fb334a0201f6/schemas) | `src/api/models/observability.py`, `src/api/models/observability_models.py`, `src/api/routes/observability.py`, `sdk/mutx/observability.py` | Material schema and vocabulary adaptation | `67d0904972d5a3ddcb27844b5b85b2dc4b37d6f2` |
+| `mc-2026-04-04-01` | 2026-04-04 | `mission-control` | [`briefing-bar-widget.tsx`](https://github.com/builderz-labs/mission-control/blob/eb7c35e950b83f73d6fd61e89f7d4b377db2ad50/src/components/dashboard/widgets/briefing-bar-widget.tsx) and [`widget-primitives.tsx`](https://github.com/builderz-labs/mission-control/blob/eb7c35e950b83f73d6fd61e89f7d4b377db2ad50/src/components/dashboard/widget-primitives.tsx) at `eb7c35e950b83f73d6fd61e89f7d4b377db2ad50` | `components/dashboard/DashboardOverviewPageClient.tsx`, `components/dashboard/livePrimitives.tsx` | Adapted briefing-bar and signal-display structure | `972ab49b0af83d15042b2301679246103cbdbab6` |
+| `predict-rlm-2026-04-13-01` | 2026-04-13 | `predict-rlm` | `Trampoline-AI/predict-rlm@5c7387afa1980b62b21a34ad0261256a95d8caa1` | Document engine, job, route, worker, CLI, dashboard, and operator-documentation paths listed in the evidence file | Adapted workflow contracts and example families with MUTX-specific lifecycle and observability | `7cde8ce0890cbb07c36d93c941e487986e56ea38` |
 
-1. Add or update the relevant project entry in `CREDITS.md`.
-2. Append a row here with the upstream project, license, upstream repo/ref, MUTX files, and a short summary of what was reused.
-3. Keep the upstream copyright and license notice intact anywhere the upstream license requires it.
-4. For Apache-2.0 sources, carry forward any upstream `NOTICE` material when the upstream project provides it.
-5. Prefer one PR to carry both the code change and the attribution update so provenance does not drift.
+## Candidates and unresolved identities
 
-## Ledger
+| Evidence ID | State | Rule |
+| --- | --- | --- |
+| `guild-ai` | Apache-2.0 candidate; no direct reuse recorded | A future port must pin an exact source ref, retain the Apache-2.0 text, and carry forward any `NOTICE` material present at that ref. |
+| `lacp` | Project identity and license unresolved; no direct reuse recorded | Do not port or make a license claim until the canonical owner, repository URL, exact ref, and license are established. |
 
-| Ledger ID | Date | Upstream | License | Upstream ref | MUTX scope | Reuse mode | Notes |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `mc-2026-04-04-01` | 2026-04-04 | Mission Control | MIT | `builderz-labs/mission-control` family; repo evidence in `UI-PORT-PLAN.md` and commit `972ab49b0af83d15042b2301679246103cbdbab6` | `components/dashboard/DashboardOverviewPageClient.tsx`, `components/dashboard/livePrimitives.tsx` | Adapted dashboard orchestration patterns | Existing repo history already records direct Mission Control reuse; this ledger entry makes that provenance durable in the legal docs. |
-| `lacp-pending` | 2026-04-04 | LACP | MIT | Record the exact upstream repo URL and commit/tag when the first direct port lands | None recorded yet | No direct reuse recorded yet | Keep LACP on this ledger so any future direct feature port ships with provenance on day one. |
-| `guild-ai-pending` | 2026-04-04 | Guild AI | Apache-2.0 | Record the exact upstream repo URL and commit/tag when the first direct port lands | None recorded yet | No direct reuse recorded yet | If Guild AI code or docs are ported later, also capture any required Apache-2.0 `NOTICE` material here and in the distribution path. |
-| `predict-rlm-2026-04-13-01` | 2026-04-13 | predict-rlm | MIT | `Trampoline-AI/predict-rlm` @ `5c7387afa1980b62b21a34ad0261256a95d8caa1` | `src/api/services/document_engine.py`, `src/api/services/document_jobs.py`, `src/api/routes/documents.py`, `src/api/document_worker.py`, `cli/commands/documents.py`, `cli/services/documents.py`, `app/dashboard/documents/page.tsx`, `components/dashboard/DocumentsPageClient.tsx`, `docs/document-workflows.md` | Adapted workflow contracts and operator documentation around upstream examples | MUTX integrates the upstream engine directly and intentionally mirrors the document analysis, contract comparison, invoice processing, and document redaction surface with MUTX-specific job, artifact, and observability layers. |
+An empty candidate row is not evidence of reuse. It is a guardrail that prevents
+an unattributed port from landing later.

--- a/docs/upstream-dep-report.md
+++ b/docs/upstream-dep-report.md
@@ -1,174 +1,122 @@
-# MUTX Upstream Dependency Report
+# MUTX upstream dependency report
 
-Last updated: 2026-04-16
+Last verified: 2026-07-15
 
-## Critical Changes (action needed now)
+This report separates three facts that older revisions conflated:
 
-| Source | Change | Impact | MUTX File | Type |
-|--------|--------|--------|-----------|------|
-| mission-control v2.0.0 | Task status `awaiting_owner` added to enum | Breaking — any MUTX code consuming task statuses must handle new value | Any task status handling | breaking |
-| mission-control v2.0.0 | Webhook retry with circuit breaker, delivery history, verify-docs | Breaking — MUTX webhooks.py (basic CRUD) far behind MC's delivery infra | `src/api/routes/webhooks.py` | breaking |
-| mission-control v2.0.0 | Session lifecycle controls (pause/terminate/continue/transcript) | Breaking — MUTX sessions.py has basic CRUD only | `src/api/routes/sessions.py` | breaking |
-| mission-control v2.0.0 | Agent sub-routes expanded (comms, evals, message, optimize, sync) | Breaking — MUTX agents.py lacks inter-agent messaging, eval framework, optimization | `src/api/routes/agents.py` | breaking |
-| Microsoft AGT | Agent Governance Toolkit released (MIT, 7 packages) | Critical — new industry baseline for agent governance, covers OWASP Agentic AI Top 10 | `src/api/routes/policies.py`, `src/api/routes/security.py` | adopt |
-| Faramesh costshield | Pre-execution cost governance module (MIT) | High — standalone budget enforcement for agent tool calls | `src/api/routes/budgets.py` | adopt |
+1. the current upstream release or head;
+2. the historical ref from which MUTX adapted or generated local material; and
+3. whether MUTX has actually validated compatibility with the current upstream.
 
-## Mission-Control Backend Delta
+Immutable license and source evidence is maintained in
+[`docs/legal/oss-attribution-evidence.json`](legal/oss-attribution-evidence.json).
 
-**MC version: v2.0.1** (2026-03-18) — jumped from v1.3.0. Major release with 189 commits.
+## Current upstream truth
 
-### API Surface: MC 101 endpoints vs MUTX ~55 endpoints
+| Project | Current audited upstream | License at audited ref | MUTX state | Required action |
+| --- | --- | --- | --- | --- |
+| agent-run | No release tags; main `9c7c3fa68413de878fae2d605c90fb334a0201f6` | MIT, Copyright (c) 2026 Builderz Labs | Local schemas are adapted; upstream package is not a runtime dependency | **QUARANTINE** current upstream package; do not import, vendor, execute, or update pending maintainer review |
+| AARM docs | Main `8eff208b98786b2c9a578b26cb7eaca440ec4020` | MIT, Copyright (c) 2023 Mintlify | MUTX’s old R1–R9 numbering drifted from the current model | Use the current mapping; close technical and organizational gaps before any conformance claim |
+| Faramesh Core | Main `e230a9ac2d12d80ed6f632db42b6e1983ccbce82`; pinned published release `v0.2.0` / `ae3ebc9066d65e4e930164881c2f2ce2be554c7f`; historical semver tag `v1.2.9` / `c85237e4e6b13745169291f60b9c6b985285dbaa` | Main: Apache-2.0; `v0.2.0` and `v1.2.9`: MPL-2.0 | CLI and gateway fetch an immutable installer and request `v0.2.0` explicitly | Run the pinned compatibility lane before changing either installer ref or release |
+| FPL | Main `b7aa0b7ad56f60428d692278a435c5e6640cec2b` | Apache-2.0 | MUTX ships FPL policy files and CLI integration | Validate parser/daemon compatibility; retain Apache-2.0 text and any future `NOTICE` |
+| Mission Control | `v2.1.0` / `b4ebc5418bea4fa9288a5c17fbddb9ba99740964` | MIT, Copyright (c) 2026 Builderz Labs | Direct dashboard pattern provenance predates the current release | Treat `v2.1.0` as the comparison baseline, not proof of compatibility |
+| Orchestra Research AI-Research-SKILLs | `v1.7.2` / `773a52944ba4747a18bd4ae9ade53fff041adcbc` | MIT, Copyright (c) 2025 Claude AI Research Skills Contributors | Catalog is pinned to `05f1958727bfc2bc22240f41d060504473c4f236` | Regenerate and validate the catalog against `v1.7.2` in a dedicated migration |
+| predict-rlm | `v0.7.2` / `4ff334dea79a2f27e96b7a50a358b0427050899e` | MIT, Copyright (c) 2026 Trampoline AI | Workflow provenance is pinned to `5c7387afa1980b62b21a34ad0261256a95d8caa1` | Validate templates, runtime prerequisites, and output contracts against `v0.7.2` |
+| Guild AI | Tag `0.9.0`; audited main `dfbefedb6ca5ce3a1341f9f00a4016420f6fc76d` | Apache-2.0 | Candidate only; no direct reuse recorded | Keep out of the distribution unless a scoped adoption decision records exact provenance |
+| LACP | Unresolved identity | Unknown | No direct reuse recorded | Do not port or make a license claim until owner, canonical repo, ref, and license are established |
 
-#### MC-Only Route Families (not in MUTX)
-| MC Route | Description | Priority |
-|----------|-------------|----------|
-| `activities/` | Real-time activity feed | Medium |
-| `adapters/` | Framework adapters (OpenClaw, CrewAI, LangGraph, AutoGen, Claude SDK) | High |
-| `alerts/` | Alert system | Low |
-| `backup/` | Backup/restore | Low |
-| `channels/` | Agent communication channels | Medium |
-| `chat/` | Embedded chat workspace | Medium |
-| `claude-tasks/`, `claude/sessions/` | Claude Code task/session bridge | Low |
-| `connect/` | Gateway connection management | High |
-| `events/` | Event streaming | Medium |
-| `frameworks/` | Framework detection/management | Medium |
-| `gateway-config/`, `gateways/` | Multi-gateway management (connect, control, discover, health) | High |
-| `github/` | GitHub Issues sync | Low |
-| `gnap/` | Git-native task persistence | Medium |
-| `hermes/` | Hermes agent observability (events, memory, tasks) | High |
-| `memory/` | Obsidian-style knowledge graph (context, graph, health, links, process, search) | High |
-| `mentions/` | @mention system | Low |
-| `nodes/` | Pipeline node management | Medium |
-| `notifications/` | Notification system | Medium |
-| `pipelines/`, `workflows/` | Pipeline/workflow orchestration | Medium |
-| `projects/` | Project management with ticket numbering | Medium |
-| `pty/` | PTY terminal integration | Low |
-| `quality-review/` | Aegis quality gate system | Medium |
-| `security-scan/`, `mcp-audit/` | Security scanning + MCP call auditing | Medium |
-| `skills/`, `registry/` | Skills Hub with bidirectional disk↔DB sync + security scanner | High |
-| `spawn/` | Agent spawn requests | Medium |
-| `standup/` | Automated standup reports | Low |
-| `super/` | Multi-tenant superadmin (tenants, provision-jobs, os-users) | Medium |
-| `system-monitor/`, `diagnostics/`, `status/` | System monitoring + diagnostics | Low |
-| `tokens/` | Token usage tracking | Medium |
-| `workload/` | Workload distribution | Low |
-| `workspaces/` | Workspace management | Medium |
+## Security hold: agent-run
 
-#### Divergent Routes (exists in both, different shape)
-| MC Route | MUTX Route | Delta |
-|----------|-----------|-------|
-| `cron/` + `schedule-parse/` + `scheduler/` | `scheduler.py` | MC has NL→cron parsing + separate cron management |
-| `exec-approvals/` | `approvals.py` | MC has exec-specific approval flow |
-| `security-audit/` | `security.py` | MC has dedicated security-audit panel |
-| `skills/` + `registry/` | `clawhub.py` | MC has full skills lifecycle; MUTX has install-only |
+The current upstream TypeScript entry point at
+[`agent-run@9c7c3fa/typescript/src/index.ts`](https://github.com/builderz-labs/agent-run/blob/9c7c3fa68413de878fae2d605c90fb334a0201f6/typescript/src/index.ts)
+contains behavior that requires coordinated security review before the package
+can be trusted as a schema/types dependency. MUTX must not recommend, install,
+import, vendor, execute, or update that package until the upstream maintainer has
+resolved the review.
 
-#### Key Breaking Changes (v1.3.0 → v2.0.0)
-1. **B1**: Task status `awaiting_owner` added — MUTX must handle new enum value
-2. **B2**: Memory system redesigned — Obsidian-style knowledge surface (6 sub-routes)
-3. **B3**: Session controls — pause/terminate/continue/transcript endpoints
-4. **B4**: Webhook delivery infra — retry with circuit breaker, delivery history, verify-docs
-5. **B5**: Agent sub-routes — comms, evals, message, optimize, sync
-6. **B6**: Cron→scheduler divergence — MC has both `/cron/` and `/scheduler/` with NL parsing
-7. **B7**: Node >=22 requirement (frontend only, no MUTX backend impact)
+MUTX’s existing observability implementation consists of local adapted schemas
+and does not need the upstream TypeScript package at runtime. The commit is
+recorded as audit evidence, not as an upgrade target. Coordinate any disclosure
+through the repository’s security process; do not publish secret material.
 
-#### MC lib/ Utilities Not in MUTX
-| Utility | Function |
-|---------|----------|
-| `skill-sync.ts` | Bidirectional disk↔DB skill sync |
-| `skill-registry.ts` | Registry client + security scanner |
-| `agent-evals.ts` | 4-layer eval framework (output, trace, component, drift) |
-| `models.ts` | Dynamic model catalog |
-| `adapters/` (7 files) | Framework adapters (OpenClaw, CrewAI, LangGraph, AutoGen, Claude SDK, generic) |
-| `security-events.ts` | Event logger + trust scoring |
+## Current AARM model
 
-## Faramesh & Governance
+The authoritative requirements are pinned at
+[`aarm-dev/docs@8eff208b/conformance/requirements.mdx`](https://github.com/aarm-dev/docs/blob/8eff208b98786b2c9a578b26cb7eaca440ec4020/conformance/requirements.mdx).
 
-### Faramesh Org (github.com/faramesh)
-- **faramesh-core** v1.2.4 (MIT, Go, 38⭐) — Runtime governance engine: CLI, SDKs, policy engine, credential broker, tamper-evident audit chain
-- **fpl-lang** (MIT, Go) — FPL policy DSL: agent-native primitives, mandatory `deny!`, NL compilation, GitOps native
-- **costshield** (MIT, Go) — Pre-execution cost governance: session/daily budgets, two-phase accounting, anomaly detection
-- **tesseract** — Pre-governance observation engine
-- **sverm** — Cross-agent behavioral analysis
-- **hub** — Open-source policy pack registry
-- **supply-chain** — Supply chain security tooling
-- **cloud-sdk** — Auth, plan gating, inter-tool mesh
-- Python/Node SDKs, UI, examples, Homebrew tap
+| ID | Level | Current meaning | MUTX status |
+| --- | --- | --- | --- |
+| R1 | MUST | Pre-execution interception, blocking/deferral, no target effects, fail closed | Partial; not demonstrated |
+| R2 | MUST | Context accumulation including data classification and original request | Partial; not demonstrated |
+| R3 | MUST | Static and contextual policy evaluation with mandatory deferral conditions | Partial; not demonstrated |
+| R4 | MUST | Distinct ALLOW, DENY, MODIFY, STEP_UP, and DEFER decisions | Partial; STEP_UP is not distinct |
+| R5 | MUST | Complete signed and offline-verifiable receipts for every action | Partial; not demonstrated |
+| R6 | MUST | Human, service, agent, session, role, and privilege identity binding | Partial; not demonstrated |
+| R7 | SHOULD | Calibrated cumulative semantic-distance tracking | Gap; current heuristic is insufficient |
+| R8 | SHOULD | Structured near-real-time telemetry, filtering, and historical export | Partial; not demonstrated |
+| R9 | SHOULD | Just-in-time operation-scoped credentials | Gap; not demonstrated |
 
-### AARM v1.0 (Autonomous Action Runtime Management)
-- Spec by Kavya Pearlman / XRSI-aligned researchers
-- 5 authorization decisions: ALLOW, DENY, MODIFY, STEP_UP, DEFER
-- Framework-agnostic, vendor-neutral runtime security spec
-- **Recommendation**: Align MUTX governance layer with AARM's 5-decision model
+**AARM Core** requires all R1–R6 MUST requirements. **AARM Extended** adds
+R7–R9. The upstream process also evaluates organizational conditions including
+community engagement, an active production deployment, a relevant recognized
+security certification, and benchmarking participation. MUTX has not published
+evidence satisfying those conditions. See
+[`docs/legal/aarm-alignment.md`](legal/aarm-alignment.md).
 
-### Microsoft Agent Governance Toolkit (AGT) — NEW April 2026
-- 7 packages: agent-os, agent-mesh, agent-runtime, agent-sre, agent-compliance, agent-marketplace, agent-lightning
-- MIT license, Python/TS/Rust/Go/.NET, 9,500+ tests
-- Covers all OWASP Agentic AI Top 10
-- <0.1ms p99 policy enforcement latency
-- **Recommendation**: Evaluate as primary or complementary governance layer
+## Mission Control comparison baseline
 
-### RPL (Reasoning Policy Language)
-- No standalone RPL project exists. FPL and AARM cover the same ground. **Ignore**.
+Mission Control `v2.1.0` supersedes the `v2.0.1` baseline used by the previous
+report. MUTX should compare behavior rather than copy its API breadth wholesale.
+The durable direct-port evidence is intentionally pinned to the upstream source
+commit that introduced the briefing pattern and to MUTX port commit
+`972ab49b0af83d15042b2301679246103cbdbab6`.
 
-## Dependency Audit
+High-value comparison areas remain:
 
-### npm Outdated Packages (26 packages)
+- framework and gateway adapters;
+- session lifecycle and transcript controls;
+- webhook delivery history and retry behavior;
+- skill registry synchronization and security scanning;
+- agent evaluation and quality-review surfaces.
 
-| Package | Current | Latest | Severity |
-|---------|---------|--------|----------|
-| react | 18.3.1 | 19.2.5 | **high** — major version behind |
-| react-dom | 18.3.1 | 19.2.5 | **high** — major version behind |
-| electron | 39.8.5 | 41.2.1 | **high** — major version behind |
-| tailwindcss | 3.4.19 | 4.2.2 | **high** — major version behind |
-| lucide-react | 0.323.0 | 1.8.0 | **high** — major version behind |
-| tailwind-merge | 2.6.1 | 3.5.0 | **medium** — major version behind |
-| sonner | 1.7.4 | 2.0.7 | **medium** — major version behind |
-| react-intersection-observer | 9.16.0 | 10.0.3 | **medium** — major version behind |
-| typescript | 5.9.3 | 6.0.2 | **medium** — major version behind |
-| @types/three | 0.169.0 | 0.183.1 | **low** — type defs |
-| resend | 6.9.3 | 6.12.0 | **low** — minor |
-| framer-motion | 12.35.2 | 12.38.0 | **low** — minor |
-| next | 16.2.3 | 16.2.4 | **low** — patch |
-| postcss | 8.5.8 | 8.5.10 | **low** — patch |
-| autoprefixer | 10.4.27 | 10.5.0 | **low** — minor |
-| eslint | 10.1.0 | 10.2.0 | **low** — minor |
-| eslint-config-next | 16.2.1 | 16.2.4 | **low** — patch |
-| postgres | 3.4.8 | 3.4.9 | **low** — patch |
-| lenis | 1.3.18 | 1.3.23 | **low** — patch |
-| ts-jest | 29.4.5 | 29.4.9 | **low** — patch |
-| @capacitor/android | 8.2.0 | 8.3.0 | **low** — minor |
-| @capacitor/core | 8.2.0 | 8.3.0 | **low** — minor |
-| globals | 17.4.0 | 17.5.0 | **low** — minor |
-| typescript-eslint | 8.57.2 | 8.58.2 | **low** — patch |
-| @types/node | 25.3.5 | 25.6.0 | **low** — type defs |
-| @types/pg | 8.18.0 | 8.20.0 | **low** — type defs |
+Each adoption should be its own issue/PR with compatibility tests and attribution.
 
-### npm Audit: **0 vulnerabilities** ✅
+## Faramesh and FPL license obligations
 
-### Python: venv not at `venv/` — likely at `.venv/` per AGENTS.md. Manual check needed.
+Faramesh Core current main and FPL current main are Apache-2.0, not MIT. The
+pinned Core `v0.2.0` release and historical `v1.2.9` tag are MPL-2.0. The
+audited refs contain no root `NOTICE` file. MUTX retains the verbatim
+third-party Apache-2.0 text at `third_party/licenses/Apache-2.0.txt` and the
+verbatim MPL-2.0 text at `third_party/licenses/MPL-2.0.txt`. A later relicense
+on main does not retroactively relicense an earlier tag. If a future upstream ref adds
+`NOTICE`, that material must be carried into the distribution when applicable.
+“AARM-aligned” is the accurate upstream status for Faramesh and does not prove
+MUTX conformance.
 
-## Watch List
+## Integration migration order
 
-| Project | URL | Relevance | Action |
-|---------|-----|-----------|--------|
-| Microsoft AGT | github.com/microsoft/agent-governance-toolkit | Agent governance, OWASP coverage | **ADOPT** |
-| Faramesh Core | github.com/faramesh/faramesh-core | Runtime governance engine | **ADOPT** |
-| FPL | github.com/faramesh/fpl-lang | Policy DSL for agents | **WATCH→ADOPT** |
-| CostShield | github.com/faramesh/costshield | Pre-execution cost governance | **ADOPT** |
-| AARM Spec | arxiv.org/html/2602.09433v1 | Runtime security spec | **ADOPT** (align conformance) |
-| k8s agent-sandbox | github.com/kubernetes-sigs/agent-sandbox | K8s agent isolation (1.8k⭐) | **WATCH** |
-| Langfuse | github.com/langfuse/langfuse | LLM observability, cost tracking | **WATCH** |
-| skillpm | npmjs.com/package/skillpm | Agent skill package manager | **WATCH** |
-| LangChain deepagents | github.com/langchain-ai/deepagents | Agent harness patterns | **WATCH** |
-| Cloudflare Dynamic Workers | Cloudflare blog | Lightweight JS sandboxing | **WATCH** |
-| Asqav SDK | github.com/jagmarques/asqav-sdk | Cryptographic audit trails | **WATCH** |
+1. Keep agent-run quarantined and use only MUTX’s local adapted schema.
+2. Close the AARM naming and claim drift before adding new conformance features.
+3. Validate the pinned Faramesh Core `v0.2.0` release and current FPL in an isolated compatibility lane.
+4. Regenerate Orchestra metadata against `v1.7.2` and review the resulting content.
+5. Exercise predict-rlm `v0.7.2` through every managed/local workflow contract.
+6. Re-audit Mission Control `v2.1.0` only for roadmap-backed capabilities.
 
 ## Changelog
+
+### 2026-07-15
+
+- Replaced mutable and broken evidence with immutable commit/tag links.
+- Corrected agent-run and Mission Control copyright years to 2026.
+- Quarantined the current agent-run package pending upstream security review.
+- Corrected AARM’s repository license notice to Copyright (c) 2023 Mintlify.
+- Replaced the obsolete AARM requirement numbering with the current Core/Extended model.
+- Corrected Faramesh/FPL from MIT and recorded the ref-specific split: Core main
+  and FPL main are Apache-2.0, while the pinned Core `v0.2.0` release and
+  historical `v1.2.9` tag are MPL-2.0.
+- Updated Mission Control to `v2.1.0`, Orchestra to `v1.7.2`, and predict-rlm to `v0.7.2`.
+- Marked LACP identity/license as unresolved and removed the unsupported MIT claim.
+
 ### 2026-04-16
-- Initial upstream dependency report
-- MC jumped from v1.3.0 to v2.0.1 — 7 breaking changes, 21 additive capabilities, 101 REST endpoints
-- Faramesh org mapped: 14 repos, core at v1.2.4, CostShield and FPL notable
-- Microsoft AGT released April 2026 — 7-package governance toolkit, MIT, critical priority
-- AARM v1.0 spec identified as industry baseline for runtime security
-- 26 npm packages outdated (5 major versions behind), 0 vulnerabilities
-- React 18→19, Tailwind 3→4, Electron 39→41 are the biggest version gaps
+
+- Initial upstream dependency report (now superseded by the verified record above).

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -17,17 +17,17 @@ Operating autonomous agents in production fails in predictable ways:
 
 | Failure Mode | What Happens | MUTX Mitigation |
 |---|---|---|
-| Unbounded tool execution | Agent calls destructive tools (shell, file delete, network) without constraint | PolicyEngine evaluates NormalizedAction before execution (R1) |
-| Context-blind gating | Individual actions look safe but the sequence is dangerous (e.g., read-credit-cards → send-email) | ContextAccumulator tracks session state; IntentSignal detects drift (R3, R4) |
-| No human override | High-risk actions execute automatically with no approval path | ApprovalService with PENDING→APPROVED/DENIED/EXPIRED lifecycle (R5) |
-| No audit trail | After an incident, there is no record of what the agent did, why, or who approved it | ReceiptGenerator creates signed ActionReceipts chained via prior_action_hashes (R6) |
+| Unbounded tool execution | Agent calls destructive tools (shell, file delete, network) without constraint | Supported supervised paths can evaluate a NormalizedAction before execution; complete current AARM R1 coverage is not yet demonstrated |
+| Context-blind gating | Individual actions look safe but the sequence is dangerous (e.g., read-credit-cards → send-email) | ContextAccumulator stores session actions and data access (partial current R2/R3); IntentSignal is a heuristic, not current R7 semantic distance |
+| No human override | High-risk actions execute automatically with no approval path | ApprovalService provides a human decision lifecycle (partial current R4; STEP_UP and DEFER are not yet distinct) |
+| No audit trail | After an incident, there is no record of what the agent did, why, or who approved it | ReceiptGenerator can create and sign ActionReceipts (partial current R5; full receipt evidence is not yet demonstrated) |
 | Credential sprawl | API keys and secrets embedded in agent configs or environment variables permanently | CredentialBroker retrieves on-demand with TTL, injects as ephemeral env vars |
 | Agent zombie processes | Agent crashes but its status remains "running" indefinitely | MonitorRuntimeState tracks heartbeats; SelfHealer recovers via RESTART/ROLLBACK |
-| Identity ambiguity | Cannot distinguish agent actions from developer actions or from different agents | JWT/API key auth + SPIFFE identity binding agent→session→human (R7) |
+| Identity ambiguity | Cannot distinguish agent actions from developer actions or from different agents | JWT/API key auth plus agent, session, and user identifiers (partial current R6; service identity and privilege scope remain gaps) |
 
 ## 3. Design Principles
 
-1. **Pre-execution gating.** Every tool call passes through ActionMediator → PolicyEngine before execution. There is no "log and allow" mode.
+1. **Pre-execution gating target.** Supported supervised paths should pass through ActionMediator → PolicyEngine before execution. Complete path coverage and fail-closed behavior must be proven before making a universal claim.
 2. **Context-aware decisions.** Policy evaluation considers accumulated session state, not just the current action in isolation.
 3. **Cryptographic receipts.** Every evaluated action produces a tamper-evident receipt with chain integrity.
 4. **Defense in depth.** Auth middleware, ownership enforcement, rate limiting, and input validation are independent layers.
@@ -108,7 +108,7 @@ src/security/                    # Governance engine (framework-agnostic)
   policy.py                      # Policy engine (465 lines)
   approvals.py                   # Approval service (395 lines)
   receipts.py                    # Cryptographic receipts (407 lines)
-  compliance.py                  # AARM conformance checker (556 lines)
+  compliance.py                  # Local AARM-alignment gap checker
   telemetry.py                   # Security telemetry exporter
 
 sdk/mutx/                        # Python SDK
@@ -955,7 +955,10 @@ Uses `selectinload` for eager loading of deployments and their events, avoiding 
 
 ## 8. Governance Engine
 
-The governance engine is the deepest subsystem in MUTX. It implements the AARM (Agent Action Rights Management) conformance requirements and provides the complete security pipeline from tool invocation interception through to cryptographic receipt generation.
+The governance engine is the deepest subsystem in MUTX. It is designed toward
+the current AARM runtime-security requirements and provides capability modules
+from tool invocation normalization through receipt generation. It is not a
+complete AARM Core implementation and is not an AARM conformance claim.
 
 The pipeline flows:
 
@@ -1481,21 +1484,26 @@ class ReceiptGenerator:
 
 ### AARMComplianceChecker
 
-Source: `src/security/compliance.py` (556 lines)
+Source: `src/security/compliance.py`
 
-Verifies 9 conformance requirements:
+The historical class and `/v1/security/compliance` route are retained for API
+compatibility. They now return a local capability-gap assessment against the
+current AARM model; they do not certify conformance.
 
-| Requirement | Level | Description | Satisfied By |
+| Requirement | Level | Current requirement | MUTX status |
 |---|---|---|---|
-| R1 | MUST | Block actions before execution based on policy | ActionMediator + PolicyEngine |
-| R2 | MUST | Validate action parameters against type, range, pattern | ParameterConstraint in ToolSchema |
-| R3 | MUST | Accumulate session context including prior actions | ContextAccumulator |
-| R4 | MUST | Evaluate intent consistency for context-dependent actions | IntentSignal + PolicyRule.require_context_alignment |
-| R5 | MUST | Support human approval workflows with timeout | ApprovalService |
-| R6 | MUST | Generate cryptographically signed receipts with full context | ReceiptGenerator + Ed25519 |
-| R7 | MUST | Bind actions to human, service, agent, and session identity | NormalizedAction (user_id, agent_id, session_id) |
-| R8 | SHOULD | Enforce least privilege through scoped, just-in-time credentials | CredentialBroker with TTL |
-| R9 | SHOULD | Export structured telemetry to security platforms | TelemetryExporter |
+| R1 | MUST | Pre-execution interception, blocking/deferral, and fail-closed behavior | Partial; not demonstrated |
+| R2 | MUST | Accumulated actions, data classifications, and original request | Partial; not demonstrated |
+| R3 | MUST | Static and contextual policy evaluation with mandatory deferral conditions | Partial; not demonstrated |
+| R4 | MUST | Distinct ALLOW, DENY, MODIFY, STEP_UP, and DEFER decisions | Partial; STEP_UP is missing as a distinct decision |
+| R5 | MUST | Complete signed, offline-verifiable receipts for every decision | Partial; not demonstrated |
+| R6 | MUST | Multi-level trusted identity binding and preservation | Partial; not demonstrated |
+| R7 | SHOULD | Calibrated cumulative semantic-distance tracking | Gap; current heuristic is not sufficient |
+| R8 | SHOULD | Structured near-real-time telemetry and historical export | Partial; not demonstrated |
+| R9 | SHOULD | Just-in-time operation-scoped credentials | Gap; not demonstrated |
+
+See [`docs/legal/aarm-alignment.md`](legal/aarm-alignment.md) for exact evidence,
+upstream verification links, technical gaps, and organizational conditions.
 
 ```python
 @dataclass
@@ -1509,7 +1517,7 @@ class ConformanceResult:
 
 @dataclass
 class AARMComplianceReport:
-    version: str = "1.0"
+    version: str = "2026-03-26"
     overall_satisfied: bool = True    # False if any MUST requirement fails
     results: list[ConformanceResult]
 
@@ -2008,7 +2016,9 @@ This is called when logging audit events to correlate them with distributed trac
 
 Source: `src/api/routes/observability.py` (580 lines)
 
-Based on the agent-run open standard for agent observability.
+Based on a local adaptation of the agent-run observability schemas. The current
+upstream package is quarantined pending maintainer security review and is not a
+runtime dependency.
 
 **Models:**
 
@@ -2486,8 +2496,9 @@ Hierarchy: **source code > OpenAPI spec (`/openapi.json`) > prose docs**
 | Metrics | prometheus_client | Apache 2.0 |
 | Tracing | OpenTelemetry SDK | Apache 2.0 |
 | Audit storage | aiosqlite | MIT |
-| Agent-run standard | builderz-labs/agent-run | MIT |
-| AARM specification | aarm-dev/docs | MIT |
+| Agent-run schema source | builderz-labs/agent-run | MIT (current package quarantined; local adaptation only) |
+| AARM documentation | aarm-dev/docs | MIT, Copyright (c) 2023 Mintlify |
+| Faramesh Core and FPL | faramesh/faramesh-core, faramesh/fpl-lang | Core main/FPL main: Apache-2.0; pinned Core `v0.2.0` and historical `v1.2.9`: MPL-2.0 |
 | Database | PostgreSQL 16 | PostgreSQL License |
 | Cache | Redis 7 | BSD 3-Clause |
 | Frontend | Next.js | MIT |
@@ -2497,4 +2508,8 @@ Hierarchy: **source code > OpenAPI spec (`/openapi.json`) > prose docs**
 
 ## 22. License
 
-MUTX is proprietary software. The governance engine (AARM) components are based on the AARM specification, which is MIT-licensed. The agent-run observability schema is based on builderz-labs/agent-run, which is MIT-licensed.
+MUTX core is source-available under BUSL-1.1 and the Python SDK is Apache-2.0.
+Runtime-security components are informed by the MIT-licensed AARM documentation
+but are not presented as AARM-conformant. The observability schema is a local
+adaptation of MIT-licensed agent-run schemas; MUTX does not execute the
+quarantined current upstream package. See `CREDITS.md` for exact refs and notices.

--- a/sdk/mutx/observability.py
+++ b/sdk/mutx/observability.py
@@ -20,8 +20,11 @@ Usage:
 Based on the agent-run open standard for agent observability.
 https://github.com/builderz-labs/agent-run
 
-MIT License - Copyright (c) 2024 builderz-labs
-https://github.com/builderz-labs/agent-run/blob/main/LICENSE
+MIT License - Copyright (c) 2026 Builderz Labs
+https://github.com/builderz-labs/agent-run/blob/9c7c3fa68413de878fae2d605c90fb334a0201f6/LICENSE
+
+Schema adaptation only. The current upstream package is quarantined pending
+maintainer security review and is not required by this module.
 """
 
 import warnings

--- a/sdk/mutx/security.py
+++ b/sdk/mutx/security.py
@@ -1,4 +1,4 @@
-"""Security API SDK - /security endpoints (AARM)."""
+"""Security API SDK - /security capability and AARM-alignment endpoints."""
 
 from __future__ import annotations
 
@@ -58,7 +58,7 @@ class GovernanceMetrics:
 
 
 class Security:
-    """SDK resource for /security endpoints (AARM)."""
+    """SDK resource for runtime-security and AARM-alignment endpoints."""
 
     def __init__(self, client: httpx.Client | httpx.AsyncClient):
         self._client = client
@@ -336,14 +336,14 @@ class Security:
         return response.json()
 
     def run_compliance_check(self) -> dict[str, Any]:
-        """Run AARM conformance checks."""
+        """Run the local AARM-alignment gap check (not conformance)."""
         self._require_sync_client()
         response = self._client.get("/security/compliance")
         response.raise_for_status()
         return response.json()
 
     async def arun_compliance_check(self) -> dict[str, Any]:
-        """Run AARM conformance checks (async)."""
+        """Run the local AARM-alignment gap check asynchronously."""
         self._require_async_client()
         response = await self._client.get("/security/compliance")
         response.raise_for_status()

--- a/src/api/models/observability.py
+++ b/src/api/models/observability.py
@@ -7,8 +7,11 @@ https://github.com/builderz-labs/agent-run
 This module provides MUTX-native schemas for tracking agent executions,
 inspired by agent-run but rebranded as MutxRun, MutxStep, etc.
 
-MIT License - Copyright (c) 2024 builderz-labs
-https://github.com/builderz-labs/agent-run/blob/main/LICENSE
+MIT License - Copyright (c) 2026 Builderz Labs
+https://github.com/builderz-labs/agent-run/blob/9c7c3fa68413de878fae2d605c90fb334a0201f6/LICENSE
+
+Schema adaptation only. The current upstream package is quarantined pending
+maintainer security review and is not required by this module.
 """
 
 import uuid

--- a/src/api/models/observability_models.py
+++ b/src/api/models/observability_models.py
@@ -7,8 +7,11 @@ These persist MutxRun, MutxStep, MutxCost, MutxProvenance, and MutxEval records.
 Based on the agent-run open standard for agent observability.
 https://github.com/builderz-labs/agent-run
 
-MIT License - Copyright (c) 2024 builderz-labs
-https://github.com/builderz-labs/agent-run/blob/main/LICENSE
+MIT License - Copyright (c) 2026 Builderz Labs
+https://github.com/builderz-labs/agent-run/blob/9c7c3fa68413de878fae2d605c90fb334a0201f6/LICENSE
+
+Schema adaptation only. The current upstream package is quarantined pending
+maintainer security review and is not required by this module.
 """
 
 import uuid

--- a/src/api/routes/observability.py
+++ b/src/api/routes/observability.py
@@ -15,8 +15,11 @@ Routes:
 Based on the agent-run open standard for agent observability.
 https://github.com/builderz-labs/agent-run
 
-MIT License - Copyright (c) 2024 builderz-labs
-https://github.com/builderz-labs/agent-run/blob/main/LICENSE
+MIT License - Copyright (c) 2026 Builderz Labs
+https://github.com/builderz-labs/agent-run/blob/9c7c3fa68413de878fae2d605c90fb334a0201f6/LICENSE
+
+Schema adaptation only. The current upstream package is quarantined pending
+maintainer security review and is not required by this module.
 """
 
 import json

--- a/src/api/routes/security.py
+++ b/src/api/routes/security.py
@@ -1,7 +1,7 @@
 """
 MUTX Security API Routes.
 
-REST API for MUTX Security Layer - AARM-compliant runtime security.
+REST API for MUTX runtime-security capabilities.
 
 Routes:
 - POST   /v1/security/actions/evaluate        - Evaluate action without executing
@@ -10,14 +10,14 @@ Routes:
 - POST   /v1/security/approvals/{id}/deny   - Deny deferred action
 - GET    /v1/security/approvals/{id}        - Get approval status
 - GET    /v1/security/receipts/{id}         - Get action receipt
-- GET    /v1/security/compliance             - Run AARM conformance checks
+- GET    /v1/security/compliance             - Run local AARM-alignment checks
 - GET    /v1/security/metrics               - Get governance metrics
 
-Based on the AARM (Autonomous Action Runtime Management) specification.
-https://github.com/aarm-dev/docs
+Informed by the AARM specification. The local check is not an AARM conformance
+report and does not establish Core, Extended, or organizational conformance.
+https://github.com/aarm-dev/docs/tree/8eff208b98786b2c9a578b26cb7eaca440ec4020
 
-MIT License - Copyright (c) 2024 aarm-dev
-https://github.com/aarm-dev/docs/blob/main/LICENSE.txt
+AARM documentation reference: MIT License, Copyright (c) 2023 Mintlify.
 """
 
 from typing import Any, Optional
@@ -108,7 +108,7 @@ class ApprovalActionRequest(BaseModel):
 
 
 class ComplianceResponse(BaseModel):
-    """AARM compliance check response."""
+    """Backward-compatible local AARM-alignment check response."""
 
     overall_satisfied: bool
     version: str
@@ -451,7 +451,7 @@ async def get_session_receipts(
 async def run_compliance_check(
     current_user: User = Depends(get_current_user),
 ):
-    """Run AARM conformance checks."""
+    """Run local capability checks mapped to AARM; not a conformance report."""
     checker = AARMComplianceChecker(
         mediator=_mediator,
         context_accumulator=_context_accumulator,

--- a/src/runtime/gateways/faramesh.py
+++ b/src/runtime/gateways/faramesh.py
@@ -1,7 +1,7 @@
 """
-Faramesh Gateway - Faramesh as AARM Implementation.
+Faramesh Gateway - MUTX integration with Faramesh.
 
-Use Faramesh as the AARM-compliant policy enforcement backend.
+Use Faramesh as an AARM-aligned policy enforcement backend.
 Faramesh provides deterministic policy evaluation via FPL (Faramesh Policy Language).
 
 https://github.com/faramesh/faramesh-core
@@ -13,8 +13,12 @@ Faramesh integration provides:
 - Credential broker for API key management
 - Cryptographic decision audit trail
 
-MIT License - Copyright (c) 2024 faramesh
-https://github.com/faramesh/faramesh-core/blob/main/LICENSE
+Faramesh Core current main and FPL current main are Apache-2.0. The pinned
+Faramesh Core v0.2.0 release and historical v1.2.9 tag are MPL-2.0; honor the
+license at the exact installed ref.
+https://github.com/faramesh/faramesh-core/blob/e230a9ac2d12d80ed6f632db42b6e1983ccbce82/LICENSE
+https://github.com/faramesh/faramesh-core/blob/v0.2.0/LICENSE
+https://github.com/faramesh/faramesh-core/blob/v1.2.9/LICENSE
 """
 
 import json
@@ -32,7 +36,11 @@ logger = logging.getLogger(__name__)
 
 
 FAREMESH_DEFAULT_DAEMON_PORT = 7777
-FAREMESH_INSTALL_URL = "https://raw.githubusercontent.com/faramesh/faramesh-core/main/install.sh"
+FAREMESH_INSTALL_REF = "ae3ebc9066d65e4e930164881c2f2ce2be554c7f"
+FAREMESH_INSTALL_VERSION = "0.2.0"
+FAREMESH_INSTALL_URL = (
+    f"https://raw.githubusercontent.com/faramesh/faramesh-core/{FAREMESH_INSTALL_REF}/install.sh"
+)
 
 
 def _default_faramesh_socket_path() -> str:
@@ -139,10 +147,10 @@ def _send_socket_request(socket_path: str, request: dict, timeout: float = 5.0) 
 
 class FarameshGateway:
     """
-    Faramesh as AARM-compliant policy enforcement backend.
+    Faramesh as an AARM-aligned policy enforcement backend.
 
     The FarameshGateway wraps the Faramesh daemon to provide
-    AARM-compliant governance for MUTX.
+    Faramesh-backed governance for MUTX; this does not establish AARM conformance.
 
     Usage:
         gateway = FarameshGateway()
@@ -402,12 +410,13 @@ class FarameshGateway:
 
             install_script = result.stdout
 
-            cmd = ["bash", "-c", install_script]
+            cmd = ["bash", "-s", "--", "--version", FAREMESH_INSTALL_VERSION]
             if non_interactive:
-                cmd = ["bash", "-c", install_script + " --non-interactive"]
+                cmd.append("--no-interactive")
 
             install_result = subprocess.run(
                 cmd,
+                input=install_script,
                 capture_output=True,
                 text=True,
                 timeout=60,

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,32 +1,22 @@
 """
-MUTX Security Layer - AARM-Compliant Runtime Security for AI Agents.
+MUTX runtime-security capability modules.
 
-Based on the AARM (Autonomous Action Runtime Management) specification.
-https://github.com/aarm-dev/docs
+These modules are informed by the AARM specification audited at
+aarm-dev/docs@8eff208b98786b2c9a578b26cb7eaca440ec4020. They provide pieces of
+the current R1-R9 model, but MUTX has not demonstrated all AARM Core technical
+tests or the organizational conditions required for a conformance claim.
 
-AARM defines what a runtime security system must do - MUTX implements it.
+Current alignment:
+- ActionMediator and PolicyEngine: partial R1 and R3
+- ContextAccumulator: partial R2; heuristic only for R7
+- PolicyEngine and ApprovalService: partial R4
+- ReceiptGenerator: partial R5
+- NormalizedAction and API authentication: partial R6
+- TelemetryExporter: partial R8
+- Least-privilege credential issuance: R9 gap
 
-Components:
-- ActionMediator: Intercepts and normalizes tool invocations (R1, R2)
-- ContextAccumulator: Tracks session state and intent (R3, R4)
-- PolicyEngine: Evaluates actions against policy (R1, R2, R4)
-- ApprovalService: Human-in-the-loop for deferred actions (R5)
-- ReceiptGenerator: Cryptographic audit receipts (R6)
-- TelemetryExporter: SIEM/SOAR integration (R9)
-
-Conformance:
-- R1: MUST block actions before execution based on policy
-- R2: MUST validate action parameters against type, range, and pattern constraints
-- R3: MUST accumulate session context including prior actions and data accessed
-- R4: MUST evaluate intent consistency for context-dependent actions
-- R5: MUST support human approval workflows with timeout handling
-- R6: MUST generate cryptographically signed receipts with full context
-- R7: MUST bind actions to human, service, agent, and session identity
-- R8: SHOULD enforce least privilege through scoped, just-in-time credentials
-- R9: SHOULD export structured telemetry to security platforms
-
-MIT License - Copyright (c) 2024 aarm-dev
-https://github.com/aarm-dev/docs/blob/main/LICENSE.txt
+See docs/legal/aarm-alignment.md for the evidence and remaining gaps.
+AARM documentation reference: MIT License, Copyright (c) 2023 Mintlify.
 """
 
 from src.security.mediator import ActionCategory, ActionMediator, NormalizedAction

--- a/src/security/approvals.py
+++ b/src/security/approvals.py
@@ -4,10 +4,11 @@ Approval Service.
 Human-in-the-loop mechanism for high-risk or ambiguous actions.
 Handles timeouts, multi-reviewer workflows, and escalation chains.
 
-AARM Requirement: R5 (MUST support human approval workflows with timeout handling)
+AARM alignment: contributes to the STEP_UP portion of current R4. The wider
+execution, timeout, and receipt requirements are not demonstrated by this service.
 
-MIT License - Copyright (c) 2024 aarm-dev
-https://github.com/aarm-dev/docs
+AARM documentation reference: MIT License, Copyright (c) 2023 Mintlify.
+https://github.com/aarm-dev/docs/tree/8eff208b98786b2c9a578b26cb7eaca440ec4020
 """
 
 import secrets

--- a/src/security/compliance.py
+++ b/src/security/compliance.py
@@ -1,21 +1,13 @@
-"""
-AARM Conformance Verification.
+"""Local capability checks mapped to the current AARM requirements.
 
-Verify MUTX satisfies all 9 AARM conformance requirements.
+This module is retained under its historical public names for API compatibility.
+Its output is an engineering gap assessment, not an AARM conformance report.
+MUTX has not demonstrated every AARM Core technical test or the organizational
+conditions required to use the designation "AARM-conformant."
 
-Requirements:
-- R1: MUST block actions before execution based on policy
-- R2: MUST validate action parameters against type, range, and pattern constraints
-- R3: MUST accumulate session context including prior actions and data accessed
-- R4: MUST evaluate intent consistency for context-dependent actions
-- R5: MUST support human approval workflows with timeout handling
-- R6: MUST generate cryptographically signed receipts with full context
-- R7: MUST bind actions to human, service, agent, and session identity
-- R8: SHOULD enforce least privilege through scoped, just-in-time credentials
-- R9: SHOULD export structured telemetry to security platforms
-
-MIT License - Copyright (c) 2024 aarm-dev
-https://github.com/aarm-dev/docs
+Specification audit ref: aarm-dev/docs@8eff208b98786b2c9a578b26cb7eaca440ec4020
+AARM documentation reference: MIT License, Copyright (c) 2023 Mintlify.
+See docs/legal/aarm-alignment.md for evidence and gaps.
 """
 
 from dataclasses import dataclass, field
@@ -23,16 +15,16 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Optional
 
-from src.security.mediator import ActionMediator
-from src.security.context import ContextAccumulator
-from src.security.policy import PolicyEngine
 from src.security.approvals import ApprovalService
+from src.security.context import ContextAccumulator
+from src.security.mediator import ActionMediator
+from src.security.policy import PolicyEngine
 from src.security.receipts import ReceiptGenerator
 from src.security.telemetry import TelemetryExporter
 
 
 class ConformanceLevel(str, Enum):
-    """Conformance level for a requirement."""
+    """Normative level assigned by the current AARM specification."""
 
     MUST = "MUST"
     SHOULD = "SHOULD"
@@ -40,7 +32,7 @@ class ConformanceLevel(str, Enum):
 
 @dataclass
 class ConformanceResult:
-    """Result of a single conformance check."""
+    """Completeness result for one current AARM requirement."""
 
     requirement_id: str
     level: ConformanceLevel
@@ -56,9 +48,9 @@ class ConformanceResult:
 
 @dataclass
 class AARMComplianceReport:
-    """Full AARM conformance report."""
+    """Backward-compatible container for the local AARM alignment assessment."""
 
-    version: str = "1.0"
+    version: str = "2026-03-26"
     checked_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     overall_satisfied: bool = True
     results: list[ConformanceResult] = field(default_factory=list)
@@ -69,52 +61,116 @@ class AARMComplianceReport:
             self.overall_satisfied = False
 
     def get_result(self, requirement_id: str) -> Optional[ConformanceResult]:
-        for r in self.results:
-            if r.requirement_id == requirement_id:
-                return r
+        for result in self.results:
+            if result.requirement_id == requirement_id:
+                return result
         return None
 
     def summary(self) -> dict[str, Any]:
-        must_results = [r for r in self.results if r.level == ConformanceLevel.MUST]
-        should_results = [r for r in self.results if r.level == ConformanceLevel.SHOULD]
-
-        must_satisfied = sum(1 for r in must_results if r.satisfied)
-        should_satisfied = sum(1 for r in should_results if r.satisfied)
+        must_results = [result for result in self.results if result.level == ConformanceLevel.MUST]
+        should_results = [
+            result for result in self.results if result.level == ConformanceLevel.SHOULD
+        ]
 
         return {
             "overall_satisfied": self.overall_satisfied,
             "total_requirements": len(self.results),
             "must_requirements": len(must_results),
-            "must_satisfied": must_satisfied,
+            "must_satisfied": sum(1 for result in must_results if result.satisfied),
             "should_requirements": len(should_results),
-            "should_satisfied": should_satisfied,
+            "should_satisfied": sum(1 for result in should_results if result.satisfied),
+            "assessment_scope": "local-capability-gap-check",
+            "conformance_claim": "none",
         }
 
 
+@dataclass(frozen=True)
+class _RequirementAssessment:
+    level: ConformanceLevel
+    description: str
+    gap: str
+    component_attribute: Optional[str] = None
+
+
+_REQUIREMENTS: dict[str, _RequirementAssessment] = {
+    "R1": _RequirementAssessment(
+        ConformanceLevel.MUST,
+        "Pre-execution interception with blocking, deferral, and fail-closed behavior",
+        "Relevant mediation and policy code exists, but interception across every execution "
+        "path, zero effects for denied/deferred actions, fail-closed unavailability, and "
+        "decision receipts have not all been demonstrated.",
+        "policy_engine",
+    ),
+    "R2": _RequirementAssessment(
+        ConformanceLevel.MUST,
+        "Context accumulation across actions, data classifications, and original intent",
+        "Session actions, data access, and original requests can be stored, but the "
+        "highest-sensitivity classification default and full production policy-path "
+        "consumption have not been demonstrated.",
+        "context_accumulator",
+    ),
+    "R3": _RequirementAssessment(
+        ConformanceLevel.MUST,
+        "Static and contextual policy evaluation with required deferral conditions",
+        "MUTX has static rules, a context signal, and parameter constraints, but lacks the "
+        "complete classification model and mandatory deferral behavior for missing context, "
+        "equal-priority conflicts, and low confidence.",
+        "policy_engine",
+    ),
+    "R4": _RequirementAssessment(
+        ConformanceLevel.MUST,
+        "Five distinct decisions: ALLOW, DENY, MODIFY, STEP_UP, and DEFER",
+        "PolicyDecision has no distinct STEP_UP value and approval is conflated with DEFER. "
+        "Dependency propagation, ordering, bounded cascades, and deny-on-timeout behavior "
+        "have not been demonstrated.",
+        "approval_service",
+    ),
+    "R5": _RequirementAssessment(
+        ConformanceLevel.MUST,
+        "Signed, offline-verifiable receipts with the complete required evidence",
+        "Receipt generation and optional Ed25519 signing exist, but signing is not mandatory, "
+        "an HMAC fallback is allowed, and the complete identity, policy, approval, deferral, "
+        "resolution, and outcome schema has not been demonstrated for every decision.",
+        "receipt_generator",
+    ),
+    "R6": _RequirementAssessment(
+        ConformanceLevel.MUST,
+        "Identity binding for human, service, agent, session, role, and privilege scope",
+        "User, agent, and session identifiers exist, but service identity, role/privilege "
+        "scope, trusted-source freshness and revocation checks, and identity preservation "
+        "through deferral/delegation have not been demonstrated.",
+        "mediator",
+    ),
+    "R7": _RequirementAssessment(
+        ConformanceLevel.SHOULD,
+        "Calibrated cumulative semantic-distance tracking from stated intent",
+        "The current denial/error/repetition heuristic is not the semantic-distance and "
+        "calibration model described by R7.",
+        "context_accumulator",
+    ),
+    "R8": _RequirementAssessment(
+        ConformanceLevel.SHOULD,
+        "Structured near-real-time telemetry with filtering and historical export",
+        "Custom events and Prometheus metrics exist, but delivery latency, filtering, "
+        "complete DEFER coverage, schema stability, and historical batch export have not "
+        "been demonstrated against a security platform.",
+        "telemetry_exporter",
+    ),
+    "R9": _RequirementAssessment(
+        ConformanceLevel.SHOULD,
+        "Just-in-time, operation-scoped least-privilege credentials",
+        "No MUTX production-path test proves short-lived operation-scoped issuance, "
+        "read-cannot-write enforcement, and credential-use audit evidence.",
+    ),
+}
+
+
 class AARMComplianceChecker:
-    """
-    Verify AARM conformance of the MUTX Security Layer.
+    """Backward-compatible local AARM alignment checker.
 
-    The AARMComplianceChecker validates that all AARM requirements
-    are properly implemented and functioning.
-
-    Usage:
-        checker = AARMComplianceChecker(
-            mediator=action_mediator,
-            context_accumulator=context_accumulator,
-            policy_engine=policy_engine,
-            approval_service=approval_service,
-            receipt_generator=receipt_generator,
-            telemetry_exporter=telemetry_exporter,
-        )
-
-        # Run full audit
-        report = checker.full_audit()
-
-        # Check individual requirement
-        result = checker.check_r1()
-        print(f"R1 satisfied: {result.satisfied}")
-        print(f"Details: {result.details}")
+    A result is ``satisfied=True`` only when the complete current upstream
+    verification is demonstrated. The presence of one component or passing unit
+    test is deliberately insufficient.
     """
 
     def __init__(
@@ -133,424 +189,58 @@ class AARMComplianceChecker:
         self.receipt_generator = receipt_generator
         self.telemetry_exporter = telemetry_exporter
 
-    def check_r1(self) -> ConformanceResult:
-        """
-        R1: MUST block actions before execution based on policy.
-
-        Verification: PolicyEngine.evaluate() returns DENY for policy violations
-        before the action reaches execution.
-        """
-        if not self.policy_engine:
-            return ConformanceResult(
-                requirement_id="R1",
-                level=ConformanceLevel.MUST,
-                description="Block actions before execution based on policy",
-                satisfied=False,
-                details="PolicyEngine not configured",
+    def _check(self, requirement_id: str) -> ConformanceResult:
+        assessment = _REQUIREMENTS[requirement_id]
+        component_state = "not applicable"
+        if assessment.component_attribute:
+            component_state = (
+                "configured"
+                if getattr(self, assessment.component_attribute) is not None
+                else "not configured"
             )
-
-        if not self.policy_engine.list_policies():
-            return ConformanceResult(
-                requirement_id="R1",
-                level=ConformanceLevel.MUST,
-                description="Block actions before execution based on policy",
-                satisfied=False,
-                details="No policies configured",
-            )
-
-        from src.security.mediator import NormalizedAction
-
-        test_action = NormalizedAction(
-            tool_name="forbidden_tool",
-            tool_args={},
-            agent_id="test-agent",
-            session_id="test-session",
-        )
-
-        result = self.policy_engine.evaluate(test_action)
-
-        can_block = result.is_denied or result.is_deferred or result.is_modified
 
         return ConformanceResult(
-            requirement_id="R1",
-            level=ConformanceLevel.MUST,
-            description="Block actions before execution based on policy",
-            satisfied=can_block,
-            details=f"PolicyEngine can return blocking decisions: {can_block}. "
-            f"Test evaluation returned: {result.decision.value}",
+            requirement_id=requirement_id,
+            level=assessment.level,
+            description=assessment.description,
+            satisfied=False,
+            details=(
+                f"Component signal: {component_state}. Gap: {assessment.gap} "
+                "This local result is not an AARM validation report."
+            ),
         )
+
+    def check_r1(self) -> ConformanceResult:
+        return self._check("R1")
 
     def check_r2(self) -> ConformanceResult:
-        """
-        R2: MUST validate action parameters against type, range, and pattern constraints.
-
-        Verification: ActionMediator.validate_parameters() correctly validates inputs.
-        """
-        if not self.mediator:
-            return ConformanceResult(
-                requirement_id="R2",
-                level=ConformanceLevel.MUST,
-                description="Validate action parameters against type, range, and pattern constraints",
-                satisfied=False,
-                details="ActionMediator not configured",
-            )
-
-        from src.security.mediator import ParameterConstraint, ToolSchema
-
-        self.mediator.register_tool(
-            ToolSchema(
-                tool_name="test_tool",
-                parameters=[
-                    ParameterConstraint(
-                        name="count",
-                        type="number",
-                        required=True,
-                        min_value=1,
-                        max_value=100,
-                    ),
-                    ParameterConstraint(
-                        name="email",
-                        type="string",
-                        pattern=r"^[\w\.-]+@[\w\.-]+\.\w+$",
-                    ),
-                ],
-            )
-        )
-
-        valid_params = {"count": 50, "email": "test@example.com"}
-        invalid_params = {"count": 200, "email": "invalid"}
-
-        is_valid_valid, _ = self.mediator.validate_parameters("test_tool", valid_params)
-        is_valid_invalid, errors = self.mediator.validate_parameters("test_tool", invalid_params)
-
-        satisfied = is_valid_valid and not is_valid_invalid
-
-        return ConformanceResult(
-            requirement_id="R2",
-            level=ConformanceLevel.MUST,
-            description="Validate action parameters against type, range, and pattern constraints",
-            satisfied=satisfied,
-            details=f"Validation correctly accepts valid params: {is_valid_valid}, "
-            f"rejects invalid params: {not is_valid_invalid}. "
-            f"Errors for invalid: {errors}",
-        )
+        return self._check("R2")
 
     def check_r3(self) -> ConformanceResult:
-        """
-        R3: MUST accumulate session context including prior actions and data accessed.
-
-        Verification: ContextAccumulator records actions and provides context for evaluation.
-        """
-        if not self.context_accumulator:
-            return ConformanceResult(
-                requirement_id="R3",
-                level=ConformanceLevel.MUST,
-                description="Accumulate session context including prior actions and data accessed",
-                satisfied=False,
-                details="ContextAccumulator not configured",
-            )
-
-        from src.security.mediator import NormalizedAction
-
-        session_id = "test-session-r3"
-        self.context_accumulator.create_session(
-            session_id=session_id,
-            agent_id="test-agent",
-            original_request="Test request",
-        )
-
-        action = NormalizedAction(
-            tool_name="test_tool",
-            tool_args={"key": "value"},
-            agent_id="test-agent",
-            session_id=session_id,
-        )
-
-        self.context_accumulator.record_action(
-            session_id=session_id,
-            action=action,
-            effect="PERMIT",
-        )
-
-        context = self.context_accumulator.get_context(session_id)
-
-        satisfied = (
-            context is not None
-            and len(context.actions) > 0
-            and context.actions[0].tool_name == "test_tool"
-        )
-
-        return ConformanceResult(
-            requirement_id="R3",
-            level=ConformanceLevel.MUST,
-            description="Accumulate session context including prior actions and data accessed",
-            satisfied=satisfied,
-            details=f"Context accumulated {len(context.actions) if context else 0} actions. "
-            f"Context available: {context is not None}",
-        )
+        return self._check("R3")
 
     def check_r4(self) -> ConformanceResult:
-        """
-        R4: MUST evaluate intent consistency for context-dependent actions.
-
-        Verification: ContextAccumulator.evaluate_intent() detects drift.
-        """
-        if not self.context_accumulator:
-            return ConformanceResult(
-                requirement_id="R4",
-                level=ConformanceLevel.MUST,
-                description="Evaluate intent consistency for context-dependent actions",
-                satisfied=False,
-                details="ContextAccumulator not configured",
-            )
-
-        from src.security.context import IntentSignal
-
-        session_id = "test-session-r4"
-        context = self.context_accumulator.create_session(
-            session_id=session_id,
-            agent_id="test-agent",
-            stated_intent="Complete the task without errors",
-        )
-
-        context.tool_call_count = 20
-        context.denied_count = 15
-
-        signal = self.context_accumulator.evaluate_intent(context)
-
-        satisfied = signal in (
-            IntentSignal.DRIFT_CONFIRMED,
-            IntentSignal.DRIFT_SUSPECTED,
-            IntentSignal.ALIGNED,
-        )
-
-        return ConformanceResult(
-            requirement_id="R4",
-            level=ConformanceLevel.MUST,
-            description="Evaluate intent consistency for context-dependent actions",
-            satisfied=satisfied,
-            details=f"Intent evaluation returned: {signal.value}. "
-            f"Detects drift with high denial rate: {satisfied}",
-        )
+        return self._check("R4")
 
     def check_r5(self) -> ConformanceResult:
-        """
-        R5: MUST support human approval workflows with timeout handling.
-
-        Verification: ApprovalService creates requests, handles timeout, allows approve/deny.
-        """
-        if not self.approval_service:
-            return ConformanceResult(
-                requirement_id="R5",
-                level=ConformanceLevel.MUST,
-                description="Support human approval workflows with timeout handling",
-                satisfied=False,
-                details="ApprovalService not configured",
-            )
-
-        from src.security.mediator import NormalizedAction
-        from src.security.approvals import ApprovalStatus
-
-        action = NormalizedAction(
-            tool_name="high_value_action",
-            tool_args={"amount": 10000},
-            agent_id="test-agent",
-            session_id="test-session",
-        )
-
-        request = self.approval_service.request_approval(
-            action=action,
-            reason="High value action requires approval",
-            timeout_minutes=5,
-        )
-
-        approved = self.approval_service.approve(request.token, reviewer="admin@test.com")
-        satisfied = (
-            approved
-            and request.status == ApprovalStatus.APPROVED
-            and request.decided_by == "admin@test.com"
-        )
-
-        return ConformanceResult(
-            requirement_id="R5",
-            level=ConformanceLevel.MUST,
-            description="Support human approval workflows with timeout handling",
-            satisfied=satisfied,
-            details=f"Approval request created. Approval workflow functional: {approved}. "
-            f"Status: {request.status.value}",
-        )
+        return self._check("R5")
 
     def check_r6(self) -> ConformanceResult:
-        """
-        R6: MUST generate cryptographically signed receipts with full context.
-
-        Verification: ReceiptGenerator creates signed receipts with context.
-        """
-        if not self.receipt_generator:
-            return ConformanceResult(
-                requirement_id="R6",
-                level=ConformanceLevel.MUST,
-                description="Generate cryptographically signed receipts with full context",
-                satisfied=False,
-                details="ReceiptGenerator not configured",
-            )
-
-        from src.security.mediator import NormalizedAction
-        from src.security.policy import PolicyDecision, PolicyDecisionResult
-
-        action = NormalizedAction(
-            tool_name="test_tool",
-            tool_args={"key": "value"},
-            agent_id="test-agent",
-            session_id="test-session",
-        )
-
-        decision = PolicyDecisionResult(
-            decision=PolicyDecision.ALLOW,
-            rule_id="allow-rule",
-            rule_name="Allow Rule",
-            reason="Allowed by policy",
-            session_id="test-session",
-            action_id=action.id,
-        )
-
-        receipt = self.receipt_generator.generate(
-            action=action,
-            context=None,
-            decision=decision,
-            outcome="executed",
-        )
-
-        self.receipt_generator.sign(receipt, b"test-private-key-32-bytes-long!!")
-
-        satisfied = (
-            receipt.receipt_id is not None
-            and receipt.action_hash is not None
-            and receipt.session_snapshot is not None
-            and receipt.is_signed
-        )
-
-        return ConformanceResult(
-            requirement_id="R6",
-            level=ConformanceLevel.MUST,
-            description="Generate cryptographically signed receipts with full context",
-            satisfied=satisfied,
-            details=f"Receipt generated with ID: {receipt.receipt_id}, "
-            f"signed: {receipt.is_signed}, "
-            f"has context: {receipt.session_snapshot is not None}",
-        )
+        return self._check("R6")
 
     def check_r7(self) -> ConformanceResult:
-        """
-        R7: MUST bind actions to human, service, agent, and session identity.
-
-        Verification: NormalizedAction contains all identity fields.
-        """
-        from src.security.mediator import NormalizedAction
-
-        action = NormalizedAction(
-            tool_name="test_tool",
-            tool_args={},
-            agent_id="agent-123",
-            session_id="session-456",
-            user_id="user-789",
-        )
-
-        satisfied = (
-            action.agent_id == "agent-123"
-            and action.session_id == "session-456"
-            and action.user_id == "user-789"
-        )
-
-        return ConformanceResult(
-            requirement_id="R7",
-            level=ConformanceLevel.MUST,
-            description="Bind actions to human, service, agent, and session identity",
-            satisfied=satisfied,
-            details=f"Action bound to agent_id: {action.agent_id}, "
-            f"session_id: {action.session_id}, user_id: {action.user_id}",
-        )
+        return self._check("R7")
 
     def check_r8(self) -> ConformanceResult:
-        """
-        R8: SHOULD enforce least privilege through scoped, just-in-time credentials.
-
-        Note: This is a SHOULD requirement - non-conformance is a warning, not a failure.
-        """
-        details = (
-            "Credential broker pattern documented but not fully implemented. "
-            "MUTX Security Layer should integrate with credential brokers "
-            "(Vault, AWS Secrets Manager, etc.) for just-in-time credential issuance. "
-            "See Faramesh integration for credential broker support."
-        )
-
-        return ConformanceResult(
-            requirement_id="R8",
-            level=ConformanceLevel.SHOULD,
-            description="Enforce least privilege through scoped, just-in-time credentials",
-            satisfied=False,
-            details=details,
-        )
+        return self._check("R8")
 
     def check_r9(self) -> ConformanceResult:
-        """
-        R9: SHOULD export structured telemetry to security platforms.
-
-        Verification: TelemetryExporter can export events and Prometheus metrics.
-        """
-        if not self.telemetry_exporter:
-            return ConformanceResult(
-                requirement_id="R9",
-                level=ConformanceLevel.SHOULD,
-                description="Export structured telemetry to security platforms",
-                satisfied=False,
-                details="TelemetryExporter not configured",
-            )
-
-        metrics = self.telemetry_exporter.get_prometheus_metrics()
-
-        return ConformanceResult(
-            requirement_id="R9",
-            level=ConformanceLevel.SHOULD,
-            description="Export structured telemetry to security platforms",
-            satisfied=True,
-            details=f"Prometheus metrics available: {len(metrics) > 0}. "
-            f"SIEM exporters configured: {len(self.telemetry_exporter._siem_exporters)}",
-        )
+        return self._check("R9")
 
     def full_audit(self) -> AARMComplianceReport:
-        """
-        Run all AARM conformance checks.
+        """Return the complete local gap assessment for current R1-R9."""
 
-        Returns:
-            AARMComplianceReport with results for all requirements
-        """
         report = AARMComplianceReport()
-
-        checks = [
-            self.check_r1,
-            self.check_r2,
-            self.check_r3,
-            self.check_r4,
-            self.check_r5,
-            self.check_r6,
-            self.check_r7,
-            self.check_r8,
-            self.check_r9,
-        ]
-
-        for check in checks:
-            try:
-                result = check()
-                report.add_result(result)
-            except Exception as e:
-                result = ConformanceResult(
-                    requirement_id=check.__name__,
-                    level=ConformanceLevel.MUST,
-                    description="Check failed with exception",
-                    satisfied=False,
-                    details=str(e),
-                )
-                report.add_result(result)
-
+        for requirement_id in _REQUIREMENTS:
+            report.add_result(self._check(requirement_id))
         return report

--- a/src/security/context.py
+++ b/src/security/context.py
@@ -8,15 +8,15 @@ Tracks session state throughout an agent's execution:
 - Tool outputs
 - Intermediate model responses
 
-AARM Requirement: R3 (MUST accumulate session context including prior actions)
-AARM Requirement: R4 (MUST evaluate intent consistency for context-dependent actions)
+AARM alignment: contributes to current R2 context accumulation. Its heuristic
+intent signal is not the calibrated semantic-distance implementation described by R7.
 
 The ContextAccumulator builds a picture of the ongoing session to enable
 context-aware policy evaluation. An action that looks fine in isolation might
 be a breach in context.
 
-MIT License - Copyright (c) 2024 aarm-dev
-https://github.com/aarm-dev/docs
+AARM documentation reference: MIT License, Copyright (c) 2023 Mintlify.
+https://github.com/aarm-dev/docs/tree/8eff208b98786b2c9a578b26cb7eaca440ec4020
 """
 
 from dataclasses import dataclass, field

--- a/src/security/mediator.py
+++ b/src/security/mediator.py
@@ -4,14 +4,15 @@ Action Mediation Layer.
 Intercepts tool invocations and normalizes them to a canonical schema,
 enabling policy evaluation against a consistent format.
 
-AARM Requirement: R1 (MUST block actions before execution based on policy)
+AARM alignment: contributes to current R1 pre-execution interception and R3
+parameter validation. This component alone does not demonstrate either requirement.
 
 The ActionMediator is the entry point for all tool calls in the MUTX security layer.
 It normalizes any tool invocation to a canonical NormalizedAction format that the
 PolicyEngine can evaluate consistently.
 
-MIT License - Copyright (c) 2024 aarm-dev
-https://github.com/aarm-dev/docs
+AARM documentation reference: MIT License, Copyright (c) 2023 Mintlify.
+https://github.com/aarm-dev/docs/tree/8eff208b98786b2c9a578b26cb7eaca440ec4020
 """
 
 import hashlib

--- a/src/security/policy.py
+++ b/src/security/policy.py
@@ -4,13 +4,12 @@ Policy Engine.
 Evaluates actions against static policy rules AND contextual intent alignment.
 Makes binary authorization decisions: allow, deny, modify, or require approval.
 
-AARM Requirements:
-- R1: MUST block actions before execution based on policy
-- R2: MUST validate action parameters against type, range, and pattern constraints
-- R4: MUST evaluate intent consistency for context-dependent actions
+AARM alignment: contributes to current R1 interception, R3 policy evaluation,
+and R4 decisions. MUTX does not yet implement all current R3 deferral conditions
+or the distinct STEP_UP and DEFER semantics required by R4.
 
-MIT License - Copyright (c) 2024 aarm-dev
-https://github.com/aarm-dev/docs
+AARM documentation reference: MIT License, Copyright (c) 2023 Mintlify.
+https://github.com/aarm-dev/docs/tree/8eff208b98786b2c9a578b26cb7eaca440ec4020
 """
 
 from dataclasses import dataclass, field

--- a/src/security/receipts.py
+++ b/src/security/receipts.py
@@ -4,10 +4,11 @@ Receipt Generator.
 Cryptographically signed records binding action, context, policy decision,
 and outcome. Enables forensic reconstruction and compliance audit trails.
 
-AARM Requirement: R6 (MUST generate cryptographically signed receipts with full context)
+AARM alignment: contributes to current R5 tamper-evident receipts. Signing is
+optional and the full current R5 receipt schema is not yet demonstrated.
 
-MIT License - Copyright (c) 2024 aarm-dev
-https://github.com/aarm-dev/docs
+AARM documentation reference: MIT License, Copyright (c) 2023 Mintlify.
+https://github.com/aarm-dev/docs/tree/8eff208b98786b2c9a578b26cb7eaca440ec4020
 """
 
 import hashlib

--- a/src/security/telemetry.py
+++ b/src/security/telemetry.py
@@ -4,10 +4,11 @@ Telemetry Exporter.
 Structured events exported to SIEM/SOAR platforms for security monitoring
 and incident response.
 
-AARM Requirement: R9 (SHOULD export structured telemetry to security platforms)
+AARM alignment: contributes to current R8 structured telemetry. The complete
+filtering, delivery, DEFER, and historical-export checks are not demonstrated.
 
-MIT License - Copyright (c) 2024 aarm-dev
-https://github.com/aarm-dev/docs
+AARM documentation reference: MIT License, Copyright (c) 2023 Mintlify.
+https://github.com/aarm-dev/docs/tree/8eff208b98786b2c9a578b26cb7eaca440ec4020
 """
 
 import json

--- a/tests/api/test_security_route.py
+++ b/tests/api/test_security_route.py
@@ -241,13 +241,15 @@ async def test_get_session_receipts(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_compliance_check(client: AsyncClient):
-    """Compliance check returns AARM conformance report."""
+    """Compatibility route returns a local AARM-alignment gap report."""
     response = await client.get("/v1/security/compliance")
     assert response.status_code == 200
     data = response.json()
     assert "overall_satisfied" in data
     assert "version" in data
     assert "results" in data
+    assert data["overall_satisfied"] is False
+    assert data["summary"]["conformance_claim"] == "none"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_faramesh_runtime.py
+++ b/tests/test_faramesh_runtime.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from unittest.mock import patch, MagicMock
 
 from cli.faramesh_runtime import (
+    FAREMESH_INSTALL_REF,
+    FAREMESH_INSTALL_VERSION,
     FarameshDaemonHealth,
     FarameshDecision,
     collect_faramesh_snapshot,
+    ensure_faramesh_installed,
     get_daemon_status,
     get_faramesh_health,
     get_pending_defers,
@@ -14,6 +17,28 @@ from cli.faramesh_runtime import (
     start_faramesh_daemon,
     _count_decisions_by_effect,
 )
+
+
+class TestFarameshInstall:
+    @patch("cli.faramesh_runtime.find_faramesh_bin")
+    @patch("cli.faramesh_runtime.subprocess.run")
+    def test_uses_immutable_installer_and_pinned_release(self, mock_run, mock_bin):
+        mock_bin.side_effect = [None, "/home/user/.local/bin/faramesh"]
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+
+        installed, bin_path = ensure_faramesh_installed()
+
+        assert installed is True
+        assert bin_path == "/home/user/.local/bin/faramesh"
+        download_command = mock_run.call_args_list[0].args[0]
+        assert FAREMESH_INSTALL_REF in download_command[2]
+        install_command = mock_run.call_args_list[2].args[0]
+        assert install_command[1:3] == ["--version", FAREMESH_INSTALL_VERSION]
+        assert "--no-interactive" in install_command
 
 
 class TestSocketReachability:

--- a/tests/test_oss_attribution_contract.py
+++ b/tests/test_oss_attribution_contract.py
@@ -1,0 +1,246 @@
+"""Regression tests for OSS attribution evidence and AARM claim boundaries."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.security.compliance import AARMComplianceChecker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EVIDENCE_PATH = ROOT / "docs/legal/oss-attribution-evidence.json"
+
+
+def _projects() -> dict[str, dict[str, object]]:
+    payload = json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert payload["verified_at"] == "2026-07-15"
+    return {project["id"]: project for project in payload["projects"]}
+
+
+def test_upstream_versions_licenses_and_refs_are_pinned() -> None:
+    projects = _projects()
+
+    expected = {
+        "agent-run": (
+            None,
+            "MIT",
+            "9c7c3fa68413de878fae2d605c90fb334a0201f6",
+        ),
+        "aarm-docs": (
+            None,
+            "MIT",
+            "8eff208b98786b2c9a578b26cb7eaca440ec4020",
+        ),
+        "faramesh-core": (
+            None,
+            "Apache-2.0",
+            "e230a9ac2d12d80ed6f632db42b6e1983ccbce82",
+        ),
+        "fpl-lang": (
+            None,
+            "Apache-2.0",
+            "b7aa0b7ad56f60428d692278a435c5e6640cec2b",
+        ),
+        "mission-control": (
+            "v2.1.0",
+            "MIT",
+            "b4ebc5418bea4fa9288a5c17fbddb9ba99740964",
+        ),
+        "orchestra-research": (
+            "v1.7.2",
+            "MIT",
+            "773a52944ba4747a18bd4ae9ade53fff041adcbc",
+        ),
+        "predict-rlm": (
+            "v0.7.2",
+            "MIT",
+            "4ff334dea79a2f27e96b7a50a358b0427050899e",
+        ),
+        "guild-ai": (
+            "0.9.0",
+            "Apache-2.0",
+            "dfbefedb6ca5ce3a1341f9f00a4016420f6fc76d",
+        ),
+        "lacp": (None, None, None),
+    }
+
+    assert set(projects) == set(expected)
+    for project_id, (version, license_id, ref) in expected.items():
+        project = projects[project_id]
+        assert project["current_version"] == version
+        assert project["license"] == license_id
+        assert project["current_ref"] == ref
+
+
+def test_every_attributed_local_path_exists() -> None:
+    for project in _projects().values():
+        for relative_path in project["local_paths"]:
+            assert (ROOT / relative_path).exists(), (
+                f"{project['id']} evidence points to missing local path {relative_path}"
+            )
+
+
+def test_evidence_uses_immutable_source_and_license_links() -> None:
+    projects = _projects()
+
+    for project_id, project in projects.items():
+        if project_id == "lacp":
+            assert project["repository"] is None
+            assert project["license_url"] is None
+            continue
+
+        current_ref = str(project["current_ref"])
+        assert current_ref in str(project["release_url"])
+        assert current_ref in str(project["license_url"])
+
+    agent_run = projects["agent-run"]
+    assert agent_run["status"] == "adapted-upstream-quarantined"
+    assert agent_run["security_review_url"].endswith(
+        "/9c7c3fa68413de878fae2d605c90fb334a0201f6/typescript/src/index.ts"
+    )
+    assert str(agent_run["security_status"]).startswith("quarantined-do-not-import")
+
+    faramesh = projects["faramesh-core"]
+    assert faramesh["latest_semver_tag"] == "v1.2.9"
+    assert faramesh["latest_semver_tag_ref"] == ("c85237e4e6b13745169291f60b9c6b985285dbaa")
+    assert faramesh["latest_semver_tag_license"] == "MPL-2.0"
+    assert faramesh["latest_semver_tag_ref"] in faramesh["latest_semver_tag_url"]
+    assert faramesh["latest_semver_tag_ref"] in faramesh["latest_semver_tag_license_url"]
+    assert faramesh["installer_ref"] == "ae3ebc9066d65e4e930164881c2f2ce2be554c7f"
+    assert faramesh["installer_version"] == "v0.2.0"
+    assert faramesh["installer_license"] == "MPL-2.0"
+    assert faramesh["installer_ref"] in faramesh["installer_source_url"]
+    assert faramesh["installer_ref"] in faramesh["installer_license_url"]
+
+
+def test_required_apache_and_mpl_license_texts_are_verbatim() -> None:
+    apache = (ROOT / "third_party/licenses/Apache-2.0.txt").read_text(encoding="utf-8")
+    sdk_license = (ROOT / "sdk/LICENSE").read_text(encoding="utf-8")
+    mpl = (ROOT / "third_party/licenses/MPL-2.0.txt").read_text(encoding="utf-8")
+
+    assert apache.startswith("                                 Apache License\n")
+    assert "Version 2.0, January 2004" in apache
+    assert "END OF TERMS AND CONDITIONS" in apache
+    assert "Faramesh contributors" not in apache
+    assert "Copyright (c) 2026 MUTX" in sdk_license
+    assert "Faramesh contributors" not in sdk_license
+    assert mpl.startswith("Mozilla Public License\nVersion 2.0\n")
+    assert "10.4. Distributing Source Code Form that is Incompatible" in mpl
+    assert "Exhibit B" in mpl
+
+
+def test_faramesh_installers_are_immutable_and_version_pinned() -> None:
+    from cli import faramesh_runtime
+    from src.runtime.gateways import faramesh
+
+    expected_ref = "ae3ebc9066d65e4e930164881c2f2ce2be554c7f"
+    for module in (faramesh_runtime, faramesh):
+        assert module.FAREMESH_INSTALL_REF == expected_ref
+        assert module.FAREMESH_INSTALL_VERSION == "0.2.0"
+        assert expected_ref in module.FAREMESH_INSTALL_URL
+        assert "/main/" not in module.FAREMESH_INSTALL_URL
+
+
+def test_faramesh_gateway_passes_pinned_version_to_installer() -> None:
+    from src.runtime.gateways.faramesh import FAREMESH_INSTALL_VERSION, FarameshGateway
+
+    gateway = FarameshGateway()
+    with (
+        patch("subprocess.run") as run,
+        patch.object(gateway, "_find_bin", return_value="/usr/local/bin/faramesh"),
+    ):
+        run.side_effect = [
+            MagicMock(returncode=0, stdout="#!/bin/sh\n", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+
+        installed, bin_path = gateway.install()
+
+    assert installed is True
+    assert bin_path == "/usr/local/bin/faramesh"
+    installer_call = run.call_args_list[1]
+    assert installer_call.args[0] == [
+        "bash",
+        "-s",
+        "--",
+        "--version",
+        FAREMESH_INSTALL_VERSION,
+        "--no-interactive",
+    ]
+    assert installer_call.kwargs["input"] == "#!/bin/sh\n"
+
+
+def test_direct_port_ledger_has_durable_evidence() -> None:
+    ledger = (ROOT / "docs/legal/oss-attribution-ledger.md").read_text(encoding="utf-8")
+
+    for evidence_id in ("agent-run", "mission-control", "predict-rlm"):
+        assert f"`{evidence_id}`" in ledger
+
+    assert "UI-PORT-PLAN.md" not in ledger
+    assert "Record the exact upstream repo URL" not in ledger
+    assert "LACP (`MIT`)" not in ledger
+
+
+def test_public_legal_docs_expose_attribution_and_alignment_pages() -> None:
+    summary = (ROOT / "SUMMARY.md").read_text(encoding="utf-8")
+    legal = (ROOT / "docs/legal/index.md").read_text(encoding="utf-8")
+
+    assert "docs/legal/oss-attribution-ledger.md" in summary
+    assert "docs/legal/aarm-alignment.md" in summary
+    assert "oss-attribution-evidence.json" in legal
+    assert "no Core or Extended conformance claim" in legal
+
+
+def test_incorrect_embedded_license_and_conformance_claims_do_not_return() -> None:
+    aarm_sources = [
+        ROOT / "src/security/__init__.py",
+        ROOT / "src/security/mediator.py",
+        ROOT / "src/security/context.py",
+        ROOT / "src/security/policy.py",
+        ROOT / "src/security/approvals.py",
+        ROOT / "src/security/receipts.py",
+        ROOT / "src/security/telemetry.py",
+        ROOT / "src/security/compliance.py",
+        ROOT / "src/api/routes/security.py",
+    ]
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in aarm_sources)
+
+    assert "Copyright (c) 2024 aarm-dev" not in combined
+    assert "AARM-Compliant Runtime Security" not in combined
+    assert "AARM-compliant runtime security" not in combined
+
+    faramesh = (ROOT / "src/runtime/gateways/faramesh.py").read_text(encoding="utf-8")
+    assert "Apache-2.0" in faramesh
+    assert "MIT License - Copyright (c) 2024 faramesh" not in faramesh
+
+    observability_sources = [
+        ROOT / "src/api/models/observability.py",
+        ROOT / "src/api/models/observability_models.py",
+        ROOT / "src/api/routes/observability.py",
+        ROOT / "sdk/mutx/observability.py",
+    ]
+    for path in observability_sources:
+        text = path.read_text(encoding="utf-8")
+        assert "Copyright (c) 2026 Builderz Labs" in text
+        assert "Copyright (c) 2024 builderz-labs" not in text
+
+
+def test_local_aarm_check_is_not_a_conformance_pass() -> None:
+    report = AARMComplianceChecker().full_audit()
+
+    assert report.version == "2026-03-26"
+    assert report.overall_satisfied is False
+    assert [result.requirement_id for result in report.results] == [
+        "R1",
+        "R2",
+        "R3",
+        "R4",
+        "R5",
+        "R6",
+        "R7",
+        "R8",
+        "R9",
+    ]
+    assert not any(result.satisfied for result in report.results)
+    assert report.summary()["conformance_claim"] == "none"

--- a/third_party/licenses/Apache-2.0.txt
+++ b/third_party/licenses/Apache-2.0.txt
@@ -199,17 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-Copyright (c) 2026 MUTX. All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/third_party/licenses/MPL-2.0.txt
+++ b/third_party/licenses/MPL-2.0.txt
@@ -1,0 +1,316 @@
+Mozilla Public License
+Version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+means each individual or legal entity that creates, contributes to the creation
+of, or owns Covered Software.
+
+1.2. “Contributor Version”
+means the combination of the Contributions of others (if any) used by a
+Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+means Source Code Form to which the initial Contributor has attached the notice
+in Exhibit A, the Executable Form of such Source Code Form, and Modifications of
+such Source Code Form, in each case including portions thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+means
+
+a. that the initial Contributor has attached the notice described in Exhibit B to
+the Covered Software; or
+b. that the Covered Software was made available under the terms of version 1.1 or
+earlier of the License, but not also under the terms of a Secondary License.
+
+1.6. “Executable Form”
+means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+means a work that combines Covered Software with other material, in a separate
+file or files, that is not Covered Software.
+
+1.8. “License”
+means this document.
+
+1.9. “Licensable”
+means having the right to grant, to the maximum extent possible, whether at the
+time of the initial grant or subsequently, any and all of the rights conveyed by
+this License.
+
+1.10. “Modifications”
+means any of the following:
+
+a. any file in Source Code Form that results from an addition to, deletion from, or
+modification of the contents of Covered Software; or
+b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+means any patent claim(s), including without limitation, method, process, and
+apparatus claims, in any patent Licensable by such Contributor that would be
+infringed, but for the grant of the License, by the making, using, selling, offering
+for sale, having made, import, or transfer of either its Contributions or its
+Contributor Version.
+
+1.12. “Secondary License”
+means either the GNU General Public License, Version 2.0, the GNU Lesser General
+Public License, Version 2.1, the GNU Affero General Public License, Version
+3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+means an individual or a legal entity exercising rights under this License. For
+legal entities, “You” includes any entity that controls, is controlled by, or is
+under common control with You. For purposes of this definition, “control” means
+(a) the power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (b) ownership of more than fifty
+percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive
+license:
+
+a. under intellectual property rights (other than patent or trademark) Licensable
+by such Contributor to use, reproduce, make available, modify, display, perform,
+distribute, and otherwise exploit its Contributions, either on an unmodified
+basis, with Modifications, or as part of a Larger Work; and
+b. under Patent Claims of such Contributor to make, use, sell, offer for sale, have
+made, import, and otherwise transfer either its Contributions or its
+Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution become
+effective for each Contribution on the date the Contributor first distributes such
+Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under this
+License. No additional rights or licenses will be implied from the distribution or
+licensing of Covered Software under this License. Notwithstanding
+Section 2.1(b) above, no patent license is granted by a Contributor:
+
+a. for any code that a Contributor has removed from Covered Software; or
+b. for infringements caused by: (i) Your and any other third party’s modifications
+of Covered Software, or (ii) the combination of its Contributions with other
+software (except as part of its Contributor Version); or
+c. under Patent Claims infringed by Covered Software in the absence of its
+Contributions.
+
+This License does not grant any rights in the trademarks, service marks, or
+logos of any Contributor (except as may be necessary to comply with the notice
+requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to distribute
+the Covered Software under a subsequent version of this License (see
+Section 10.2) or under the terms of a Secondary License (if permitted under the terms of
+Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its Contributions are
+its original creation(s) or it has sufficient rights to grant the rights to its
+Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under applicable
+copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+Section 2.1.
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under the terms of
+this License. You must inform recipients that the Source Code Form of the Covered
+Software is governed by the terms of this License, and how they can obtain a copy
+of this License. You may not attempt to alter or restrict the recipients’
+rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+a. such Covered Software must also be made available in Source Code Form, as
+described in Section 3.1, and You must inform recipients of the Executable Form how
+they can obtain a copy of such Source Code Form by reasonable means in a timely
+manner, at a charge no more than the cost of distribution to the recipient; and
+b. You may distribute such Executable Form under the terms of this License, or
+sublicense it under different terms, provided that the license for the Executable
+Form does not attempt to limit or alter the recipients’ rights in the Source Code
+Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice, provided
+that You also comply with the requirements of this License for the Covered
+Software. If the Larger Work is a combination of Covered Software with a work
+governed by one or more Secondary Licenses, and the Covered Software is not
+Incompatible With Secondary Licenses, this License permits You to additionally distribute
+such Covered Software under the terms of such Secondary License(s), so that the
+recipient of the Larger Work may, at their option, further distribute the
+Covered Software under the terms of either this License or such Secondary License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices (including
+copyright notices, patent notices, disclaimers of warranty, or limitations of
+liability) contained within the Source Code Form of the Covered Software, except that
+You may alter any license notices to the extent required to remedy known factual
+inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support, indemnity
+or liability obligations to one or more recipients of Covered Software. However,
+You may do so only on Your own behalf, and not on behalf of any Contributor. You
+must make it absolutely clear that any such warranty, support, indemnity, or
+liability obligation is offered by You alone, and You hereby agree to indemnify
+every Contributor for any liability incurred by such Contributor as a result of
+warranty, support, indemnity or liability terms You offer. You may include
+additional disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+If it is impossible for You to comply with any of the terms of this License with
+respect to some or all of the Covered Software due to statute, judicial order,
+or regulation then You must: (a) comply with the terms of this License to the
+maximum extent possible; and (b) describe the limitations and the code they
+affect. Such description must be placed in a text file included with all distributions
+of the Covered Software under this License. Except to the extent prohibited by
+statute or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+fail to comply with any of its terms. However, if You become compliant, then the
+rights granted under this License from a particular Contributor are reinstated
+(a) provisionally, unless and until such Contributor explicitly and finally
+terminates Your grants, and (b) on an ongoing basis, if such Contributor fails to
+notify You of the non-compliance by some reasonable means prior to 60 days after
+You have come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor notifies You of the
+non-compliance by some reasonable means, this is the first time You have
+received notice of non-compliance with this License from such Contributor, and You
+become compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions, counter-claims, and
+cross-claims) alleging that a Contributor Version directly or indirectly infringes any
+patent, then the rights granted to You by any and all Contributors for the
+Covered Software under Section 2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+license agreements (excluding distributors and resellers) which have been validly
+granted by You or Your distributors under this License prior to termination
+shall survive termination.
+
+6. Disclaimer of Warranty
+
+Covered Software is provided under this License on an “as is” basis, without
+warranty of any kind, either expressed, implied, or statutory, including, without
+limitation, warranties that the Covered Software is free of defects,
+merchantable, fit for a particular purpose or non-infringing. The entire risk as to the
+quality and performance of the Covered Software is with You. Should any Covered
+Software prove defective in any respect, You (not any Contributor) assume the cost
+of any necessary servicing, repair, or correction. This disclaimer of warranty
+constitutes an essential part of this License. No use of any Covered Software is
+authorized under this License except under this disclaimer.
+
+7. Limitation of Liability
+
+Under no circumstances and under no legal theory, whether tort (including
+negligence), contract, or otherwise, shall any Contributor, or anyone who distributes
+Covered Software as permitted above, be liable to You for any direct, indirect,
+special, incidental, or consequential damages of any character including,
+without limitation, damages for lost profits, loss of goodwill, work stoppage,
+computer failure or malfunction, or any and all other commercial damages or losses,
+even if such party shall have been informed of the possibility of such damages.
+This limitation of liability shall not apply to liability for death or personal
+injury resulting from such party’s negligence to the extent applicable law
+prohibits such limitation. Some jurisdictions do not allow the exclusion or limitation
+of incidental or consequential damages, so this exclusion and limitation may not
+apply to You.
+
+8. Litigation
+
+Any litigation relating to this License may be brought only in the courts of a
+jurisdiction where the defendant maintains its principal place of business and
+such litigation shall be governed by laws of that jurisdiction, without reference
+to its conflict-of-law provisions. Nothing in this Section shall prevent a
+party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+This License represents the complete agreement concerning the subject matter
+hereof. If any provision of this License is held to be unenforceable, such
+provision shall be reformed only to the extent necessary to make it enforceable. Any law
+or regulation which provides that the language of a contract shall be construed
+against the drafter shall not be used to construe this License against a
+Contributor.
+
+10. Versions of the License
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section 10.3,
+no one other than the license steward has the right to modify or publish new
+versions of this License. Each version will be given a distinguishing version
+number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version of the
+License under which You originally received the Covered Software, or under the
+terms of any subsequent version published by the license steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to create a
+new license for such software, you may create and use a modified version of this
+License if you rename the license and remove any references to the name of the
+license steward (except to note that such modified license differs from this
+License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With Secondary
+Licenses under the terms of this version of the License, the notice described
+in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+  This Source Code Form is subject to the terms of the Mozilla Public License,
+  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+  obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+  This Source Code Form is “Incompatible With Secondary Licenses”, as defined
+  by the Mozilla Public License, v. 2.0.


### PR DESCRIPTION
## Summary
- replace mutable/broken OSS evidence with pinned machine-readable refs and validated local paths
- correct agent-run, AARM, Faramesh/FPL, Mission Control, Orchestra, predict-rlm, Guild AI, and unresolved LACP license/version claims
- quarantine current agent-run upstream package pending coordinated maintainer security review while retaining local schema attribution
- remap AARM R1-R9 to the current Core/Extended model and turn the compatibility endpoint into an honest local gap check
- update public legal docs, whitepaper, CLI/SDK wording, embedded headers, OpenAPI/types, and durable regression tests

## Important truth corrections
- Faramesh Core/FPL are Apache-2.0; Core current tag is v1.2.9
- AARM repository license is MIT, Copyright (c) 2023 Mintlify; current Core is R1-R6 and Extended is R1-R9
- Mission Control is v2.1.0; Orchestra is v1.7.2; predict-rlm is v0.7.2
- LACP identity/license remains unresolved and no reuse is recorded
- MUTX does not currently claim AARM Core, Extended, or organizational conformance

## Validation
- `ruff check` across all changed Python surfaces
- `python -m compileall` across changed Python surfaces
- `pytest tests/test_oss_attribution_contract.py tests/api/test_security_route.py -q` (27 passed)
- `npm run lint`
- `npm run typecheck`
- `npm test -- --runInBand tests/unit/lib_docs.test.ts` (53 suites / 435 tests passed)
- OpenAPI and TypeScript API types regenerated
- `git diff --check`

Related to #3688.
