### PR TITLE
docs(security): map OWASP agentic risks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,13 @@ jobs:
               - 'tests/api/**'
               - 'tests/unit/python/**'
               - 'tests/test_cli_*.py'
+              - 'tests/test_agentic_risk_matrix_docs.py'
               - 'tests/test_generate_homebrew_formula.py'
               - 'tests/test_release_soft_launch.py'
               - 'tests/test_sdk_*.py'
               - 'tests/test_hosted_llm_executor.py'
+              - 'docs/security/agentic_risk_matrix.md'
+              - 'docs/gtm/competitive_notes.md'
               - 'scripts/check_requirements_compat.py'
             frontend:
               - 'app/**'
@@ -122,6 +125,7 @@ jobs:
             tests/api \
             tests/unit/python \
             tests/test_cli_*.py \
+            tests/test_agentic_risk_matrix_docs.py \
             tests/test_generate_homebrew_formula.py \
             tests/test_release_soft_launch.py \
             tests/test_sdk_*.py \

--- a/docs/gtm/competitive_notes.md
+++ b/docs/gtm/competitive_notes.md
@@ -5,7 +5,8 @@ icon: chart-bar
 
 # Competitive Notes
 
-Last updated: 2026-04-20
+Last full competitive review: 2026-04-20
+OWASP mapping updated: 2026-07-16
 Primary benchmark: Microsoft Agent Governance Toolkit v3.1.0
 
 ## Market Positioning
@@ -26,7 +27,7 @@ These are **adjacent, not identical**. AGT is SDK-first (developer tooling). MUT
 | Credential brokering | ✅ 6 backends + TTL | ❌ None | **MUTX ahead** |
 | Context-aware eval | ⚠️ Session context plus heuristic intent signal; current AARM R2/R3/R7 incomplete | ⚠️ Partial | Unverified |
 | Runtime supervision | ✅ Faramesh 13-framework | ❌ SDK-level only | **MUTX ahead** |
-| OWASP ASI 2026 | ❌ No mapping | ✅ 10/10 | AGT ahead |
+| [OWASP Top 10 for Agentic Applications 2026](../security/agentic_risk_matrix.md) | ⚠️ All 10 mapped: 8 partial, 2 gaps; not 10/10 coverage | ✅ Claims 10/10 | AGT evidence stronger; mapping parity only |
 | Shadow AI discovery | ❌ None | ✅ agent-discovery | AGT ahead |
 | MCP security scanner | ❌ None | ✅ MCPServerPolicy | AGT ahead |
 | Prompt injection eval | ❌ None | ✅ 12-vector audit | AGT ahead |
@@ -49,7 +50,8 @@ These are **adjacent, not identical**. AGT is SDK-first (developer tooling). MUT
 
 ### Don't claim until built
 - AARM Core or Extended conformance (technical and organizational evidence is incomplete)
-- OWASP Agentic Top 10 coverage (need mapping doc)
+- OWASP 10/10 coverage (the evidence matrix records partial controls and gaps,
+  not comprehensive coverage)
 - Multi-language SDK (TypeScript priority)
 - Shadow AI discovery
 - MCP security scanning

--- a/docs/security/agentic_risk_matrix.md
+++ b/docs/security/agentic_risk_matrix.md
@@ -1,0 +1,86 @@
+---
+description: Evidence-based mapping of the OWASP Top 10 for Agentic Applications 2026 to MUTX controls and gaps.
+---
+
+# OWASP agentic risk matrix
+
+This document maps the **OWASP Top 10 for Agentic Applications 2026** to
+MUTX as it exists at commit `95ec55d9a49f68c488dc08c9f6fecabfadb57afe`,
+audited on 2026-07-16. It is an engineering gap assessment, not an OWASP
+certification, an implementation-level verification, or a “10/10 coverage”
+claim.
+
+The risk names and ordering come from OWASP's primary publications:
+
+- [OWASP Top 10 for Agentic Applications for 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
+- [OWASP launch article with the ASI01–ASI10 taxonomy](https://genai.owasp.org/2025/12/09/owasp-top-10-for-agentic-applications-the-benchmark-for-agentic-security-in-the-age-of-autonomous-ai/)
+
+## How to read this matrix
+
+- **Partial** means source-backed controls are relevant to the risk, but
+  material attack paths or verification requirements remain open.
+- **Gap** means MUTX has no verified control for the core risk. Adjacent
+  inventory, authentication, or observability does not change that status.
+- A file's existence is not proof that every deployed agent path uses it.
+  Runtime configuration and end-to-end enforcement still need production-path
+  evidence.
+- **AARM overlap** identifies related requirements in the
+  [current MUTX AARM assessment](../legal/aarm-alignment.md). It does not imply
+  that AARM or OWASP coverage has been demonstrated.
+
+## Current mapping
+
+| ID | Official risk | Status | Source-backed MUTX capability | Explicit gap | AARM overlap |
+| --- | --- | --- | --- | --- | --- |
+| ASI01 | Agent Goal Hijack | Partial | [`ContextAccumulator`](../../src/security/context.py) records the original request, stated intent, actions, and heuristic intent signals; [`PolicyEngine`](../../src/security/policy.py) can make a rule depend on a supplied drift signal. | There is no direct or indirect prompt-injection detector, trusted/untrusted content boundary, source labeling, or calibrated semantic goal comparison. Context is process-local, and the policy path only uses it when a caller supplies it. Universal pre-execution enforcement is not demonstrated. | R1, R2, R3, R7, R8 |
+| ASI02 | Tool Misuse & Exploitation | Partial | [`ActionMediator`](../../src/security/mediator.py) supports registered tool schemas and parameter constraints; [`PolicyEngine`](../../src/security/policy.py) supports deny/modify/defer rules and limited command-pattern checks; [`FarameshSupervisor`](../../src/api/services/faramesh_supervisor.py) defaults direct launches off and allowlists executables and environment keys. | Unregistered tools pass schema validation, command checks are regex-based, and interception is not proven across every framework/runtime path. There is no general capability-scoped tool token, per-call network/data boundary, or complete fail-closed proof. | R1, R3, R4, R5, R9 |
+| ASI03 | Identity & Privilege Abuse | Partial | API users and agents have separate authentication paths in [`middleware/auth.py`](../../src/api/middleware/auth.py); owned-resource lookups are centralized in [`auth/ownership.py`](../../src/api/auth/ownership.py); the repo also contains a [`SPIFFEIdentityProvider`](../../src/api/services/spiffe_identity.py) and a multi-backend [`CredentialBroker`](../../src/api/services/credential_broker.py). | Workload identity is not bound to every normalized action, policy decision, receipt, or delegated call. The SPIFFE provider falls back to environment identity and treats validation as successful when the SPIRE binary is absent. Revocation, freshness, role/privilege propagation, and operation-scoped credentials are not demonstrated end to end. | R5, R6, R9 |
+| ASI04 | Agentic Supply Chain Vulnerabilities | Partial | Dependency lockfiles and pinned GitHub Actions constrain part of the software supply chain; CI scans the frontend container with Trivy in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml); the local skill catalog records upstream repository/commit metadata in [`assistant_control_plane.py`](../../src/api/services/assistant_control_plane.py). | MUTX does not verify signed provenance or attestations for agent models, MCP servers, tools, skills, prompts, or runtime updates. The skill install flow changes agent configuration but has no malware/policy scanner, and there is no MCP security scanner. Container scanning covers only one artifact class. | R1, R3, R5, R8 |
+| ASI05 | Unexpected Code Execution | Partial | [`PolicyEngine.validate_command_constraints()`](../../src/security/policy.py) rejects a small set of dangerous shell strings; [`FarameshSupervisor`](../../src/api/services/faramesh_supervisor.py) launches argument arrays without a shell and restricts commands, environment overrides, and policy paths when configured. | Pattern matching is bypassable and is not code or AST validation. MUTX does not provide a verified OS sandbox, filesystem boundary, syscall policy, network-egress policy, resource quota, or isolation proof for every code-capable agent/tool path. | R1, R3, R4, R5 |
+| ASI06 | Memory & Context Poisoning | Gap | [`ContextAccumulator`](../../src/security/context.py) records session context for policy input, while the RAG surface in [`routes/rag.py`](../../src/api/routes/rag.py) validates payload size and requires an authenticated user. These are inventory and input-bounding controls, not memory-integrity controls. | RAG accepts arbitrary text and caller-selected collection names without provenance, sanitization, trust scoring, approval, integrity versioning, deletion review, or tenant namespacing. Search uses a shared default collection, and context has no poisoned-memory detection or trusted-source separation. | R2, R3, R5, R7, R8 |
+| ASI07 | Insecure Inter-Agent Communication | Gap | [`routes/swarms.py`](../../src/api/routes/swarms.py) enforces ownership for swarm membership and bounds replicas. HMAC-capable outbound webhooks and agent API keys exist elsewhere, but they are not an inter-agent security protocol. | The swarm surface manages membership and scale only. There is no authenticated and authorized agent-to-agent message envelope, sender attestation, payload integrity, replay protection, schema validation, trust-boundary policy, delivery provenance, or per-peer rate limit. | R2, R5, R6, R8 |
+| ASI08 | Cascading Failures | Partial | [`monitoring.py`](../../src/api/services/monitoring.py) marks stale agents failed and emits alerts/events; [`self_healer.py`](../../src/api/services/self_healer.py) has bounded retries and rollback hooks; swarm replica limits and [`middleware/rate_limit.py`](../../src/api/middleware/rate_limit.py) provide local bounds. | These controls observe or recover individual components. There is no dependency graph, cascade-aware budget, fan-out/depth limit, circuit breaker for agent/tool chains, global kill switch, failure-domain isolation proof, or test showing one compromised agent cannot propagate harm. | R2, R3, R4, R7, R8 |
+| ASI09 | Human-Agent Trust Exploitation | Partial | [`ApprovalService`](../../src/security/approvals.py) represents pending/approved/denied/expired decisions, and [`routes/security.py`](../../src/api/routes/security.py) exposes authenticated human-approval endpoints with security telemetry. | The approval record does not prove that reviewers receive trustworthy provenance, uncertainty, alternatives, or a clear rendering of agent-supplied content versus system facts. Reviewer identity/authority, anti-replay binding, phishing-resistant confirmation, and tests against persuasive or deceptive output are incomplete. | R4, R5, R6, R8 |
+| ASI10 | Rogue Agents | Partial | Agent heartbeat/status handling, manual stop and rollback routes, [`monitoring.py`](../../src/api/services/monitoring.py), governance telemetry in [`security/telemetry.py`](../../src/security/telemetry.py), and supervised-process stop controls provide pieces of detection and containment. | Health checks detect liveness, not behavioral integrity. MUTX has no calibrated anomaly model for goal drift, collusion, concealment, self-replication, or reward hacking; no cross-agent quarantine; and no demonstrated emergency stop that revokes credentials, network access, pending work, and delegated authority atomically. | R1, R2, R3, R4, R5, R7, R8, R9 |
+
+## Evidence boundaries
+
+The following distinctions prevent this matrix from becoming a marketing
+claim:
+
+1. Authentication is not authorization for an agent action. A valid user,
+   agent key, or SVID does not prove least privilege for a specific tool call.
+2. Logging is not prevention. Receipts, traces, and alerts help investigation,
+   but do not stop a hijacked goal, poisoned memory, or cascading action.
+3. Approval is not automatically informed consent. The reviewer needs trusted
+   context, bound action parameters, authoritative identity, expiry, and replay
+   protection.
+4. Process supervision is not sandboxing. An allowlisted executable can still
+   access excessive files, credentials, or network destinations.
+5. Dependency scanning is not agentic supply-chain verification. Models,
+   prompts, skills, tools, MCP servers, registries, and runtime configuration
+   require provenance and policy of their own.
+
+## Closure priorities
+
+1. Isolate RAG data by tenant and agent; add source provenance, integrity
+   versioning, trust policy, and poison-screening before retrieval or memory
+   writes (ASI06).
+2. Define an authenticated inter-agent envelope with workload identity,
+   authorization, schema validation, nonce/expiry, replay protection, and
+   per-peer limits before adding swarm messaging (ASI07).
+3. Prove one fail-closed mediation path for every supported runtime, then add
+   OS-level isolation and outbound data/network policy for code-capable tools
+   (ASI01, ASI02, ASI05).
+4. Bind human, service, agent, session, role, privilege, credential scope, and
+   delegation chain to decisions and receipts (ASI03, ASI09).
+5. Require signed provenance and security policy for skills, MCP servers,
+   tools, models, prompts, and release artifacts; keep unverified upstreams out
+   of execution paths (ASI04).
+6. Add cascade budgets, dependency-aware circuit breaking, behavioral anomaly
+   detection, quarantine, and an atomic emergency stop with credential
+   revocation (ASI08, ASI10).
+
+Reassess every row after those controls are integrated and production-path
+tests exist. Until then, the truthful summary is **eight partial mappings and
+two gaps**, not comprehensive coverage.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -54,6 +54,7 @@ echo "Running expanded Python validation suite..."
   tests/api \
   tests/unit/python \
   tests/test_cli_*.py \
+  tests/test_agentic_risk_matrix_docs.py \
   tests/test_generate_homebrew_formula.py \
   tests/test_release_soft_launch.py \
   tests/test_sdk_*.py \

--- a/tests/test_agentic_risk_matrix_docs.py
+++ b/tests/test_agentic_risk_matrix_docs.py
@@ -1,0 +1,62 @@
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = REPO_ROOT / "docs" / "security" / "agentic_risk_matrix.md"
+COMPETITIVE_NOTES_PATH = REPO_ROOT / "docs" / "gtm" / "competitive_notes.md"
+
+OFFICIAL_RISKS = {
+    "ASI01": "Agent Goal Hijack",
+    "ASI02": "Tool Misuse & Exploitation",
+    "ASI03": "Identity & Privilege Abuse",
+    "ASI04": "Agentic Supply Chain Vulnerabilities",
+    "ASI05": "Unexpected Code Execution",
+    "ASI06": "Memory & Context Poisoning",
+    "ASI07": "Insecure Inter-Agent Communication",
+    "ASI08": "Cascading Failures",
+    "ASI09": "Human-Agent Trust Exploitation",
+    "ASI10": "Rogue Agents",
+}
+
+
+def _matrix_rows(matrix: str) -> dict[str, tuple[str, str]]:
+    row_pattern = re.compile(
+        r"^\| (ASI(?:0[1-9]|10)) \| ([^|]+?) \| (Partial|Gap) \|",
+        re.MULTILINE,
+    )
+    return {
+        risk_id: (name.strip(), status)
+        for risk_id, name, status in row_pattern.findall(matrix)
+    }
+
+
+def test_agentic_risk_matrix_uses_the_complete_official_taxonomy() -> None:
+    matrix = MATRIX_PATH.read_text(encoding="utf-8")
+    rows = _matrix_rows(matrix)
+
+    assert list(rows) == list(OFFICIAL_RISKS)
+    assert {
+        risk_id: name for risk_id, (name, _status) in rows.items()
+    } == OFFICIAL_RISKS
+    assert sum(status == "Partial" for _name, status in rows.values()) == 8
+    assert sum(status == "Gap" for _name, status in rows.values()) == 2
+
+
+def test_agentic_risk_matrix_preserves_truthful_claim_boundaries() -> None:
+    matrix = MATRIX_PATH.read_text(encoding="utf-8")
+    competitive_notes = COMPETITIVE_NOTES_PATH.read_text(encoding="utf-8")
+    normalized_matrix = " ".join(matrix.split())
+
+    assert "not an OWASP certification" in normalized_matrix
+    assert "not comprehensive coverage" in normalized_matrix
+    assert "../security/agentic_risk_matrix.md" in competitive_notes
+    assert "not 10/10 coverage" in competitive_notes
+
+
+def test_agentic_risk_matrix_local_evidence_links_exist() -> None:
+    matrix = MATRIX_PATH.read_text(encoding="utf-8")
+    local_targets = re.findall(r"\]\(((?:\.\./)+[^)#]+)\)", matrix)
+
+    assert local_targets
+    for target in local_targets:
+        assert (MATRIX_PATH.parent / target).resolve().is_file(), target


### PR DESCRIPTION
## What changed

- add a source-grounded matrix for all ten OWASP Top 10 for Agentic Applications 2026 risks
- distinguish eight partial mappings from two core gaps instead of claiming blanket coverage
- map each risk to concrete MUTX files, explicit missing controls, and current AARM overlaps
- correct the AGT parity row and its claim boundary
- add a docs contract that locks the official ASI01–ASI10 names/order and status summary

## Why

The parity tracker said MUTX had no OWASP mapping, while the issue wording treated a mapping as if it could establish coverage. This change documents what the repository actually implements and what remains open. In particular, memory/context poisoning and secure inter-agent communication remain gaps; adjacent authentication and observability controls are not presented as mitigations.

## Validation

- `python -m pytest tests/test_agentic_risk_matrix_docs.py tests/test_docs_drift.py tests/test_contributing_docs_truth.py -q` — 20 passed
- `python -m ruff check tests/test_agentic_risk_matrix_docs.py`
- `python -m black --check tests/test_agentic_risk_matrix_docs.py`
- `git diff origin/main...HEAD --check`

Closes #3789
