### PR TITLE
fix(api): restore audit route application imports

### DIFF
--- a/src/api/routes/audit.py
+++ b/src/api/routes/audit.py
@@ -178,7 +178,7 @@ async def query_audit_events(
     dependencies=[Depends(require_roles("ADMIN", "AUDIT_ADMIN"))],
 )
 async def export_audit_evidence(
-    current_user: Annotated[SSOTokenUser, Depends(get_current_user)],
+    current_user: Annotated[SSOTokenUser, Depends(get_current_sso_user)],
     run_id: Annotated[str | None, Query(description="Run ID to export")] = None,
     session_id: Annotated[str | None, Query(description="Session ID to export")] = None,
 ) -> AuditEvidenceExportResponse:


### PR DESCRIPTION
## Summary
- use the consolidated SSO dependency for the audit evidence export route
- restore FastAPI application import and generated-contract validation on `main`

## Validation
- `ruff check src/api/routes/audit.py`
- `python -m pytest tests/test_generate_openapi.py tests/test_docs_drift.py tests/api/test_governed_runtime.py -q` (35 passed)

Closes #3849