### PR TITLE
fix(docs): restore v1.3 release entrypoint

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -30,6 +30,7 @@
 * [Python SDK](docs/sdk.md)
 * [Support](support.md)
 * [Release notes](docs/releases/v1.4.md)
+  * [v1.3 release notes](docs/releases/v1.3.md)
   * [v1.5 release checklist](docs/releases/v1.5-checklist.md)
 * [Legal and attribution](docs/legal/index.md)
   * [OSS attribution ledger](docs/legal/oss-attribution-ledger.md)


### PR DESCRIPTION
## Summary
- restore the archived v1.3 release-notes link in the GitBook navigation
- preserve v1.4 as the current release entrypoint
- clear the baseline `test_release_soft_launch` failure inherited by every active feature PR

## Root cause
The site redesign replaced the v1.3 navigation entry with v1.4, but the release contract intentionally requires the prior release to remain reachable from repository documentation entrypoints.

## Validation
- `uvx --from pytest==9.0.3 --with pytest-asyncio --with httpx --with sqlalchemy --with aiosqlite pytest tests/test_release_soft_launch.py -q` — 4 passed
- `git diff --check` — pass