### PR TITLE
feat: refresh Orchestra Research catalog to v1.7.2

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -101,14 +101,15 @@ that provenance pin; the two are intentionally reported separately.
 - **License:** MIT — Copyright (c) 2025 Claude AI Research Skills Contributors
 - **Current upstream release:** `v1.7.2`
   (`773a52944ba4747a18bd4ae9ade53fff041adcbc`)
-- **MUTX integration pin:**
-  `05f1958727bfc2bc22240f41d060504473c4f236`
+- **MUTX integration pin:** `v1.7.2`
+  (`773a52944ba4747a18bd4ae9ade53fff041adcbc`)
 
 MUTX imports catalog metadata, curates install bundles and swarm blueprints, and
-provides `scripts/sync_orchestra_research_skills.py`. The upstream skill content
+provides deterministic catalog generation and runtime sync scripts. The v1.7.2
+catalog contains 98 upstream skills, including the three Agent-Native Research
+Artifact roles. The upstream skill content
 remains attributed to Orchestra Research and to the upstream authors documented
-in that repository. The difference between the current release and the MUTX pin
-is an explicit upgrade gap, not hidden drift.
+in that repository.
 
 ### predict-rlm
 

--- a/docs/legal/oss-attribution-evidence.json
+++ b/docs/legal/oss-attribution-evidence.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "verified_at": "2026-07-15",
+  "verified_at": "2026-07-22",
   "projects": [
     {
       "id": "agent-run",
@@ -118,7 +118,7 @@
     {
       "id": "orchestra-research",
       "name": "Orchestra Research AI-Research-SKILLs",
-      "status": "integrated-behind-upstream",
+      "status": "integrated-current",
       "repository": "https://github.com/Orchestra-Research/AI-Research-SKILLs",
       "license": "MIT",
       "copyright": "Copyright (c) 2025 Claude AI Research Skills Contributors",
@@ -126,8 +126,10 @@
       "current_version": "v1.7.2",
       "release_url": "https://github.com/Orchestra-Research/AI-Research-SKILLs/commit/773a52944ba4747a18bd4ae9ade53fff041adcbc",
       "license_url": "https://github.com/Orchestra-Research/AI-Research-SKILLs/blob/773a52944ba4747a18bd4ae9ade53fff041adcbc/LICENSE",
-      "integration_ref": "05f1958727bfc2bc22240f41d060504473c4f236",
+      "integration_ref": "773a52944ba4747a18bd4ae9ade53fff041adcbc",
+      "integration_version": "v1.7.2",
       "local_paths": [
+        "scripts/build_orchestra_research_catalog.py",
         "scripts/sync_orchestra_research_skills.py",
         "src/api/data/orchestra_research_catalog.json",
         "docs/orchestra-research.md"

--- a/docs/orchestra-research.md
+++ b/docs/orchestra-research.md
@@ -8,7 +8,8 @@ MUTX ships a pinned integration with Orchestra Research's `AI-Research-SKILLs` r
 
 Upstream source of truth:
 - repo: `https://github.com/Orchestra-Research/AI-Research-SKILLs`
-- pinned commit: `05f1958727bfc2bc22240f41d060504473c4f236`
+- pinned release: `v1.7.2`
+- pinned commit: `773a52944ba4747a18bd4ae9ade53fff041adcbc`
 - license: `MIT`
 
 MUTX does not rewrite the upstream skill content into first-party docs. Instead it ships:
@@ -17,6 +18,18 @@ MUTX does not rewrite the upstream skill content into first-party docs. Instead 
 - starter templates that preload those bundles into OpenClaw-backed assistants
 - swarm blueprints for multi-agent orchestration
 - a sync script that copies the upstream skill tree into the MUTX-managed runtime root
+
+The checked-in manifest is reproducibly generated from the immutable release
+checkout and contains all 98 v1.7.2 skills. That includes the Agent-Native
+Research Artifact compiler, live research manager, and rigor reviewer added
+after MUTX's original integration.
+
+Regenerate and verify the catalog from an audited checkout:
+
+```bash
+python scripts/build_orchestra_research_catalog.py --source /path/to/AI-Research-SKILLs
+python scripts/build_orchestra_research_catalog.py --source /path/to/AI-Research-SKILLs --check
+```
 
 ## What ships
 
@@ -45,6 +58,7 @@ MUTX does not rewrite the upstream skill content into first-party docs. Instead 
 - `orchestra_rag_lab`
 - `orchestra_post_training_lab`
 - `orchestra_inference_lab`
+- `orchestra_multimodal_guardrails`
 
 These are still OpenClaw/MUTX assistants under the hood. The difference is the default skill payload and the attached orchestration metadata.
 
@@ -55,6 +69,7 @@ These are still OpenClaw/MUTX assistants under the hood. The difference is the d
 - `trainer-eval-safety`
 - `rag-ship-room`
 - `inference-ops-lane`
+- `multimodal-review-loop`
 
 These are recommendation objects, not auto-spawned clusters. They exist to make orchestration explicit instead of tribal.
 

--- a/docs/upstream-dep-report.md
+++ b/docs/upstream-dep-report.md
@@ -1,6 +1,6 @@
 # MUTX upstream dependency report
 
-Last verified: 2026-07-15
+Last verified: 2026-07-22
 
 This report separates three facts that older revisions conflated:
 
@@ -20,7 +20,7 @@ Immutable license and source evidence is maintained in
 | Faramesh Core | Main `e230a9ac2d12d80ed6f632db42b6e1983ccbce82`; pinned published release `v0.2.0` / `ae3ebc9066d65e4e930164881c2f2ce2be554c7f`; historical semver tag `v1.2.9` / `c85237e4e6b13745169291f60b9c6b985285dbaa` | Main: Apache-2.0; `v0.2.0` and `v1.2.9`: MPL-2.0 | CLI and gateway fetch an immutable installer and request `v0.2.0` explicitly | Run the pinned compatibility lane before changing either installer ref or release |
 | FPL | Main `b7aa0b7ad56f60428d692278a435c5e6640cec2b` | Apache-2.0 | MUTX ships FPL policy files and CLI integration | Validate parser/daemon compatibility; retain Apache-2.0 text and any future `NOTICE` |
 | Mission Control | `v2.1.0` / `b4ebc5418bea4fa9288a5c17fbddb9ba99740964` | MIT, Copyright (c) 2026 Builderz Labs | Direct dashboard pattern provenance predates the current release | Treat `v2.1.0` as the comparison baseline, not proof of compatibility |
-| Orchestra Research AI-Research-SKILLs | `v1.7.2` / `773a52944ba4747a18bd4ae9ade53fff041adcbc` | MIT, Copyright (c) 2025 Claude AI Research Skills Contributors | Catalog is pinned to `05f1958727bfc2bc22240f41d060504473c4f236` | Regenerate and validate the catalog against `v1.7.2` in a dedicated migration |
+| Orchestra Research AI-Research-SKILLs | `v1.7.2` / `773a52944ba4747a18bd4ae9ade53fff041adcbc` | MIT, Copyright (c) 2025 Claude AI Research Skills Contributors | Catalog and runtime sync are pinned to v1.7.2; all 98 skills and curated references validate | Regenerate with the deterministic builder whenever the release pin moves |
 | predict-rlm | `v0.7.2` / `4ff334dea79a2f27e96b7a50a358b0427050899e` | MIT, Copyright (c) 2026 Trampoline AI | Workflow provenance is pinned to `5c7387afa1980b62b21a34ad0261256a95d8caa1` | Validate templates, runtime prerequisites, and output contracts against `v0.7.2` |
 | Guild AI | Tag `0.9.0`; audited main `dfbefedb6ca5ce3a1341f9f00a4016420f6fc76d` | Apache-2.0 | Candidate only; no direct reuse recorded | Keep out of the distribution unless a scoped adoption decision records exact provenance |
 | LACP | Unresolved identity | Unknown | No direct reuse recorded | Do not port or make a license claim until owner, canonical repo, ref, and license are established |
@@ -98,11 +98,18 @@ MUTX conformance.
 1. Keep agent-run quarantined and use only MUTX’s local adapted schema.
 2. Close the AARM naming and claim drift before adding new conformance features.
 3. Validate the pinned Faramesh Core `v0.2.0` release and current FPL in an isolated compatibility lane.
-4. Regenerate Orchestra metadata against `v1.7.2` and review the resulting content.
+4. Keep the regenerated Orchestra v1.7.2 catalog and curated reference checks green.
 5. Exercise predict-rlm `v0.7.2` through every managed/local workflow contract.
 6. Re-audit Mission Control `v2.1.0` only for roadmap-backed capabilities.
 
 ## Changelog
+
+### 2026-07-22
+
+- Regenerated the Orchestra Research catalog from the immutable v1.7.2 commit.
+- Added the three Agent-Native Research Artifact skills introduced upstream.
+- Added deterministic catalog generation and closed the dangling multimodal
+  template/blueprint references in the original integration.
 
 ### 2026-07-15
 

--- a/scripts/build_orchestra_research_catalog.py
+++ b/scripts/build_orchestra_research_catalog.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Build the MUTX Orchestra Research catalog from an immutable checkout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CATALOG = ROOT / "src/api/data/orchestra_research_catalog.json"
+DEFAULT_REPO_URL = "https://github.com/Orchestra-Research/AI-Research-SKILLs"
+DEFAULT_RELEASE = "v1.7.2"
+DEFAULT_COMMIT = "773a52944ba4747a18bd4ae9ade53fff041adcbc"
+SKIP_ROOTS = {
+    ".git",
+    ".github",
+    "anthropic_official_docs",
+    "demos",
+    "dev_data",
+    "docs",
+    "packages",
+}
+
+CATEGORY_NAMES = {
+    "0-autoresearch-skill": "Autoresearch",
+    "03-fine-tuning": "Fine-Tuning",
+    "06-post-training": "Post-Training",
+    "07-safety-alignment": "Safety & Alignment",
+    "12-inference-serving": "Inference & Serving",
+    "13-mlops": "MLOps",
+    "15-rag": "RAG",
+    "20-ml-paper-writing": "ML Paper Writing",
+}
+
+
+def _git(source: Path, *args: str) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=source,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def _category_name(category_id: str) -> str:
+    if category_id in CATEGORY_NAMES:
+        return CATEGORY_NAMES[category_id]
+    label = re.sub(r"^\d+-", "", category_id).replace("-", " ")
+    return label.title()
+
+
+def _frontmatter(markdown: str, path: Path) -> dict[str, Any]:
+    if not markdown.startswith("---\n"):
+        raise ValueError(f"{path} has no YAML frontmatter")
+    try:
+        raw_frontmatter, _body = markdown[4:].split("\n---\n", 1)
+    except ValueError as exc:
+        raise ValueError(f"{path} has unterminated YAML frontmatter") from exc
+    payload = yaml.safe_load(raw_frontmatter)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} frontmatter must be an object")
+    return payload
+
+
+def _display_name(markdown: str, fallback: str) -> str:
+    match = re.search(r"^#\s+(.+?)\s*$", markdown, flags=re.MULTILINE)
+    return match.group(1).strip() if match else fallback
+
+
+def discover_skills(source: Path) -> list[dict[str, Any]]:
+    """Normalize every upstream SKILL.md into MUTX catalog metadata."""
+    skills: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    seen_names: set[str] = set()
+
+    for skill_md in sorted(source.rglob("SKILL.md")):
+        relative_file = skill_md.relative_to(source)
+        if any(part in SKIP_ROOTS for part in relative_file.parts):
+            continue
+
+        skill_dir = skill_md.parent
+        upstream_path = skill_dir.relative_to(source)
+        markdown = skill_md.read_text(encoding="utf-8")
+        metadata = _frontmatter(markdown, skill_md)
+        skill_id = skill_dir.name
+        canonical_name = str(metadata.get("name") or "").strip()
+        description = str(metadata.get("description") or "").strip()
+        author = str(metadata.get("author") or "Orchestra Research").strip()
+        raw_tags = metadata.get("tags") or []
+
+        if not canonical_name or not description:
+            raise ValueError(f"{skill_md} must define name and description")
+        if not isinstance(raw_tags, list) or not all(isinstance(tag, str) for tag in raw_tags):
+            raise ValueError(f"{skill_md} tags must be a string list")
+        if skill_id in seen_ids:
+            raise ValueError(f"duplicate skill id: {skill_id}")
+        if canonical_name in seen_names:
+            raise ValueError(f"duplicate canonical skill name: {canonical_name}")
+        seen_ids.add(skill_id)
+        seen_names.add(canonical_name)
+
+        category_id = upstream_path.parts[0]
+        skills.append(
+            {
+                "id": skill_id,
+                "canonical_name": canonical_name,
+                "name": _display_name(markdown, canonical_name),
+                "description": description,
+                "author": author,
+                "category_id": category_id,
+                "category_name": _category_name(category_id),
+                "upstream_path": upstream_path.as_posix(),
+                "tags": raw_tags,
+                "has_references": (skill_dir / "references").is_dir(),
+                "has_templates": (skill_dir / "templates").is_dir(),
+                "has_scripts": (skill_dir / "scripts").is_dir(),
+            }
+        )
+
+    return skills
+
+
+def source_metadata(source: Path, *, expected_commit: str, release: str) -> dict[str, Any]:
+    commit = _git(source, "rev-parse", "HEAD")
+    if commit != expected_commit:
+        raise ValueError(f"source checkout is {commit}; expected {expected_commit}")
+    commit_date = _git(source, "show", "-s", "--format=%cI", "HEAD")
+    return {
+        "name": "Orchestra Research AI-Research-SKILLs",
+        "repo_url": DEFAULT_REPO_URL,
+        "version": release,
+        "commit": commit,
+        "commit_date": commit_date,
+        "commit_subject": _git(source, "show", "-s", "--format=%s", "HEAD"),
+        "release_url": f"{DEFAULT_REPO_URL}/releases/tag/{release}",
+        "license": "MIT",
+        "attribution": (
+            "Catalog metadata derived from Orchestra Research upstream repository. "
+            "Skill content remains credited to Orchestra Research and upstream project authors."
+        ),
+    }
+
+
+def validate_catalog(catalog: dict[str, Any]) -> None:
+    skill_ids = {str(item["id"]) for item in catalog["skills"]}
+    bundles = {str(item["id"]): item for item in catalog["bundles"]}
+    template_ids = {str(item["id"]) for item in catalog["templates"]}
+    blueprint_ids = {str(item["id"]) for item in catalog["swarm_blueprints"]}
+
+    for bundle_id, bundle in bundles.items():
+        missing = set(bundle.get("skill_ids") or []) - skill_ids
+        if missing:
+            raise ValueError(f"bundle {bundle_id} references missing skills: {sorted(missing)}")
+        if bundle.get("recommended_template_id") not in template_ids:
+            raise ValueError(f"bundle {bundle_id} references a missing template")
+        if bundle.get("recommended_swarm_blueprint_id") not in blueprint_ids:
+            raise ValueError(f"bundle {bundle_id} references a missing swarm blueprint")
+
+    for template in catalog["templates"]:
+        missing_bundles = set(template.get("bundle_ids") or []) - bundles.keys()
+        missing_skills = set(template.get("default_config", {}).get("skills") or []) - skill_ids
+        if missing_bundles or missing_skills:
+            raise ValueError(
+                f"template {template['id']} has missing references: "
+                f"bundles={sorted(missing_bundles)}, skills={sorted(missing_skills)}"
+            )
+
+    for blueprint in catalog["swarm_blueprints"]:
+        for role in blueprint.get("roles") or []:
+            if role.get("bundle_id") not in bundles:
+                raise ValueError(f"blueprint {blueprint['id']} references a missing bundle")
+
+
+def build_catalog(
+    existing: dict[str, Any],
+    *,
+    source: dict[str, Any],
+    skills: list[dict[str, Any]],
+) -> dict[str, Any]:
+    catalog = {
+        "source": source,
+        "skills": skills,
+        "bundles": deepcopy(existing.get("bundles") or []),
+        "swarm_blueprints": deepcopy(existing.get("swarm_blueprints") or []),
+        "templates": deepcopy(existing.get("templates") or []),
+    }
+    version_date = str(source["commit_date"])[:10].replace("-", ".")
+    pin_message = f"Pinned to Orchestra Research {source['version']} at commit {source['commit']}."
+    for template in catalog["templates"]:
+        template["version"] = version_date
+        template["validation_message"] = pin_message
+    validate_catalog(catalog)
+    return catalog
+
+
+def _render(catalog: dict[str, Any]) -> str:
+    return json.dumps(catalog, indent=2, ensure_ascii=False) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Regenerate the Orchestra Research catalog from a pinned checkout."
+    )
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--output", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--commit", default=DEFAULT_COMMIT)
+    parser.add_argument("--release", default=DEFAULT_RELEASE)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    existing = json.loads(args.catalog.read_text(encoding="utf-8"))
+    catalog = build_catalog(
+        existing,
+        source=source_metadata(
+            args.source.resolve(), expected_commit=args.commit, release=args.release
+        ),
+        skills=discover_skills(args.source.resolve()),
+    )
+    rendered = _render(catalog)
+    if args.check:
+        if not args.output.exists() or args.output.read_text(encoding="utf-8") != rendered:
+            raise SystemExit("Orchestra Research catalog is stale")
+        return
+    args.output.write_text(rendered, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_orchestra_research_skills.py
+++ b/scripts/sync_orchestra_research_skills.py
@@ -9,7 +9,8 @@ import tempfile
 from pathlib import Path
 
 DEFAULT_REPO_URL = "https://github.com/Orchestra-Research/AI-Research-SKILLs.git"
-DEFAULT_COMMIT = "05f1958727bfc2bc22240f41d060504473c4f236"
+DEFAULT_RELEASE = "v1.7.2"
+DEFAULT_COMMIT = "773a52944ba4747a18bd4ae9ade53fff041adcbc"
 DEFAULT_DEST = Path.home() / ".mutx" / "skills" / "orchestra-research"
 SKIP_ROOTS = {"packages", "docs", "demos", "dev_data", "anthropic_official_docs", ".git", ".github"}
 
@@ -60,6 +61,7 @@ def sync_skills(source_root: Path, dest_root: Path, *, clean: bool) -> dict[str,
 
     manifest = {
         "repo_url": DEFAULT_REPO_URL,
+        "version": DEFAULT_RELEASE,
         "commit": run("git", "rev-parse", "HEAD", cwd=source_root),
         "skill_count": len(copied),
         "skills": copied,

--- a/src/api/data/orchestra_research_catalog.json
+++ b/src/api/data/orchestra_research_catalog.json
@@ -2,9 +2,11 @@
   "source": {
     "name": "Orchestra Research AI-Research-SKILLs",
     "repo_url": "https://github.com/Orchestra-Research/AI-Research-SKILLs",
-    "commit": "05f1958727bfc2bc22240f41d060504473c4f236",
-    "commit_date": "2026-04-10T11:02:43-07:00",
-    "commit_subject": "Merge pull request #47 from Gitsamshi/main",
+    "version": "v1.7.2",
+    "commit": "773a52944ba4747a18bd4ae9ade53fff041adcbc",
+    "commit_date": "2026-06-15T21:36:40-04:00",
+    "commit_subject": "release: v1.7.2 — ship Qoder agent auto-detection to npm",
+    "release_url": "https://github.com/Orchestra-Research/AI-Research-SKILLs/releases/tag/v1.7.2",
     "license": "MIT",
     "attribution": "Catalog metadata derived from Orchestra Research upstream repository. Skill content remains credited to Orchestra Research and upstream project authors."
   },
@@ -60,7 +62,7 @@
       "id": "mamba",
       "canonical_name": "mamba-architecture",
       "name": "Mamba - Selective State Space Models",
-      "description": "State-space model with O(n) complexity vs Transformers' O(n\u00b2). 5\u00d7 faster inference, million-token sequences, no KV cache. Selective SSM with hardware-aware design. Mamba-1 (d_state=16) and Mamba-2 (d_state=128, multi-head). Models 130M-2.8B on HuggingFace.",
+      "description": "State-space model with O(n) complexity vs Transformers' O(n²). 5× faster inference, million-token sequences, no KV cache. Selective SSM with hardware-aware design. Mamba-1 (d_state=16) and Mamba-2 (d_state=128, multi-head). Models 130M-2.8B on HuggingFace.",
       "author": "Orchestra Research",
       "category_id": "01-model-architecture",
       "category_name": "Model Architecture",
@@ -391,7 +393,7 @@
       "id": "nemo-curator",
       "canonical_name": "nemo-curator",
       "name": "NeMo Curator - GPU-Accelerated Data Curation",
-      "description": "GPU-accelerated data curation for LLM training. Supports text/image/video/audio. Features fuzzy deduplication (16\u00d7 faster), quality filtering (30+ heuristics), semantic deduplication, PII redaction, NSFW detection. Scales across GPUs with RAPIDS. Use for preparing high-quality training datasets, cleaning web data, or deduplicating large corpora.",
+      "description": "GPU-accelerated data curation for LLM training. Supports text/image/video/audio. Features fuzzy deduplication (16× faster), quality filtering (30+ heuristics), semantic deduplication, PII redaction, NSFW detection. Scales across GPUs with RAPIDS. Use for preparing high-quality training datasets, cleaning web data, or deduplicating large corpora.",
       "author": "Orchestra Research",
       "category_id": "05-data-processing",
       "category_name": "Data Processing",
@@ -489,7 +491,7 @@
       "id": "openrlhf",
       "canonical_name": "openrlhf-training",
       "name": "OpenRLHF - High-Performance RLHF Training",
-      "description": "High-performance RLHF framework with Ray+vLLM acceleration. Use for PPO, GRPO, RLOO, DPO training of large models (7B-70B+). Built on Ray, vLLM, ZeRO-3. 2\u00d7 faster than DeepSpeedChat with distributed architecture and GPU resource sharing.",
+      "description": "High-performance RLHF framework with Ray+vLLM acceleration. Use for PPO, GRPO, RLOO, DPO training of large models (7B-70B+). Built on Ray, vLLM, ZeRO-3. 2× faster than DeepSpeedChat with distributed architecture and GPU resource sharing.",
       "author": "Orchestra Research",
       "category_id": "06-post-training",
       "category_name": "Post-Training",
@@ -1034,7 +1036,7 @@
       "id": "gptq",
       "canonical_name": "gptq",
       "name": "GPTQ (Generative Pre-trained Transformer Quantization)",
-      "description": "Post-training 4-bit quantization for LLMs with minimal accuracy loss. Use for deploying large models (70B, 405B) on consumer GPUs, when you need 4\u00d7 memory reduction with <2% perplexity degradation, or for faster inference (3-4\u00d7 speedup) vs FP16. Integrates with transformers and PEFT for QLoRA fine-tuning.",
+      "description": "Post-training 4-bit quantization for LLMs with minimal accuracy loss. Use for deploying large models (70B, 405B) on consumer GPUs, when you need 4× memory reduction with <2% perplexity degradation, or for faster inference (3-4× speedup) vs FP16. Integrates with transformers and PEFT for QLoRA fine-tuning.",
       "author": "Orchestra Research",
       "category_id": "10-optimization",
       "category_name": "Optimization",
@@ -1080,7 +1082,7 @@
       "id": "ml-training-recipes",
       "canonical_name": "ml-training-recipes",
       "name": "ML Training Recipes",
-      "description": "Battle-tested PyTorch training recipes for all domains \u2014 LLMs, vision, diffusion, medical imaging, protein/drug discovery, spatial omics, genomics. Covers training loops, optimizer selection (AdamW, Muon), LR scheduling, mixed precision, debugging, and systematic experimentation. Use when training or fine-tuning neural networks, debugging loss spikes or OOM, choosing architectures, or optimizing GPU throughput.",
+      "description": "Battle-tested PyTorch training recipes for all domains — LLMs, vision, diffusion, medical imaging, protein/drug discovery, spatial omics, genomics. Covers training loops, optimizer selection (AdamW, Muon), LR scheduling, mixed precision, debugging, and systematic experimentation. Use when training or fine-tuning neural networks, debugging loss spikes or OOM, choosing architectures, or optimizing GPU throughput.",
       "author": "dailycafi",
       "category_id": "10-optimization",
       "category_name": "Optimization",
@@ -1180,7 +1182,7 @@
       "id": "llama-cpp",
       "canonical_name": "llama-cpp",
       "name": "llama.cpp",
-      "description": "Runs LLM inference on CPU, Apple Silicon, and consumer GPUs without NVIDIA hardware. Use for edge deployment, M1/M2/M3 Macs, AMD/Intel GPUs, or when CUDA is unavailable. Supports GGUF quantization (1.5-8 bit) for reduced memory and 4-10\u00d7 speedup vs PyTorch on CPU.",
+      "description": "Runs LLM inference on CPU, Apple Silicon, and consumer GPUs without NVIDIA hardware. Use for edge deployment, M1/M2/M3 Macs, AMD/Intel GPUs, or when CUDA is unavailable. Supports GGUF quantization (1.5-8 bit) for reduced memory and 4-10× speedup vs PyTorch on CPU.",
       "author": "Orchestra Research",
       "category_id": "12-inference-serving",
       "category_name": "Inference & Serving",
@@ -1206,7 +1208,7 @@
       "id": "sglang",
       "canonical_name": "sglang",
       "name": "SGLang",
-      "description": "Fast structured generation and serving for LLMs with RadixAttention prefix caching. Use for JSON/regex outputs, constrained decoding, agentic workflows with tool calls, or when you need 5\u00d7 faster inference than vLLM with prefix sharing. Powers 300,000+ GPUs at xAI, AMD, NVIDIA, and LinkedIn.",
+      "description": "Fast structured generation and serving for LLMs with RadixAttention prefix caching. Use for JSON/regex outputs, constrained decoding, agentic workflows with tool calls, or when you need 5× faster inference than vLLM with prefix sharing. Powers 300,000+ GPUs at xAI, AMD, NVIDIA, and LinkedIn.",
       "author": "Orchestra Research",
       "category_id": "12-inference-serving",
       "category_name": "Inference & Serving",
@@ -2108,7 +2110,7 @@
       "id": "moe-training",
       "canonical_name": "moe-training",
       "name": "MoE Training: Mixture of Experts",
-      "description": "Train Mixture of Experts (MoE) models using DeepSpeed or HuggingFace. Use when training large-scale models with limited compute (5\u00d7 cost reduction vs dense models), implementing sparse architectures like Mixtral 8x7B or DeepSeek-V3, or scaling model capacity without proportional compute increase. Covers MoE architectures, routing mechanisms, load balancing, expert parallelism, and inference optimization.",
+      "description": "Train Mixture of Experts (MoE) models using DeepSpeed or HuggingFace. Use when training large-scale models with limited compute (5× cost reduction vs dense models), implementing sparse architectures like Mixtral 8x7B or DeepSeek-V3, or scaling model capacity without proportional compute increase. Covers MoE architectures, routing mechanisms, load balancing, expert parallelism, and inference optimization.",
       "author": "Orchestra Research",
       "category_id": "19-emerging-techniques",
       "category_name": "Emerging Techniques",
@@ -2134,7 +2136,7 @@
       "id": "speculative-decoding",
       "canonical_name": "speculative-decoding",
       "name": "Speculative Decoding: Accelerating LLM Inference",
-      "description": "Accelerate LLM inference using speculative decoding, Medusa multiple heads, and lookahead decoding techniques. Use when optimizing inference speed (1.5-3.6\u00d7 speedup), reducing latency for real-time applications, or deploying models with limited compute. Covers draft models, tree-based attention, Jacobi iteration, parallel token generation, and production deployment strategies.",
+      "description": "Accelerate LLM inference using speculative decoding, Medusa multiple heads, and lookahead decoding techniques. Use when optimizing inference speed (1.5-3.6× speedup), reducing latency for real-time applications, or deploying models with limited compute. Covers draft models, tree-based attention, Jacobi iteration, parallel token generation, and production deployment strategies.",
       "author": "Orchestra Research",
       "category_id": "19-emerging-techniques",
       "category_name": "Emerging Techniques",
@@ -2293,6 +2295,74 @@
         "Cognitive Science"
       ],
       "has_references": false,
+      "has_templates": false,
+      "has_scripts": false
+    },
+    {
+      "id": "compiler",
+      "canonical_name": "ara-compiler",
+      "name": "Universal ARA Compiler",
+      "description": "Compiles any research input — PDF papers, GitHub repositories, experiment logs, code directories, or raw notes — into a complete Agent-Native Research Artifact (ARA) with cognitive layer (claims, concepts, heuristics), physical layer (configs, code stubs), exploration graph, and grounded evidence. Use when ingesting a paper or codebase into a structured, machine-executable knowledge package, building an ARA from scratch, or converting research outputs into a falsifiable, agent-traversable form.",
+      "author": "Orchestra Research",
+      "category_id": "22-agent-native-research-artifact",
+      "category_name": "Agent Native Research Artifact",
+      "upstream_path": "22-agent-native-research-artifact/compiler",
+      "tags": [
+        "ARA",
+        "Research Artifacts",
+        "Knowledge Extraction",
+        "Paper Ingestion",
+        "Exploration Graph",
+        "Provenance",
+        "Research Tooling",
+        "Epistemic Compilation"
+      ],
+      "has_references": true,
+      "has_templates": false,
+      "has_scripts": false
+    },
+    {
+      "id": "research-manager",
+      "canonical_name": "ara-research-manager",
+      "name": "Live Research Project Manager (Live PM)",
+      "description": "Records research provenance as a post-task epilogue, scanning conversation history at the end of a coding or research session to extract decisions, experiments, dead ends, claims, heuristics, and pivots, and writing them into the ara/ directory with user-vs-AI provenance tags. Use as a session epilogue — never during execution — to maintain a faithful, auditable trace of how a research project actually evolved.",
+      "author": "Orchestra Research",
+      "category_id": "22-agent-native-research-artifact",
+      "category_name": "Agent Native Research Artifact",
+      "upstream_path": "22-agent-native-research-artifact/research-manager",
+      "tags": [
+        "ARA",
+        "Research Recording",
+        "Provenance",
+        "Session Logging",
+        "Knowledge Management",
+        "Exploration Tree",
+        "Research Tooling"
+      ],
+      "has_references": true,
+      "has_templates": false,
+      "has_scripts": false
+    },
+    {
+      "id": "rigor-reviewer",
+      "canonical_name": "ara-rigor-reviewer",
+      "name": "ARA Seal Level 2: Semantic Epistemic Review",
+      "description": "Performs ARA Seal Level 2 semantic epistemic review on Agent-Native Research Artifacts, scoring six dimensions (evidence relevance, falsifiability, scope calibration, argument coherence, exploration integrity, methodological rigor) and producing a constructive, severity-ranked report with a Strong Accept-to-Reject recommendation. Use after Level 1 structural validation passes, when an ARA needs an objective epistemic critique before publication or release.",
+      "author": "Orchestra Research",
+      "category_id": "22-agent-native-research-artifact",
+      "category_name": "Agent Native Research Artifact",
+      "upstream_path": "22-agent-native-research-artifact/rigor-reviewer",
+      "tags": [
+        "ARA",
+        "Epistemic Review",
+        "Research Rigor",
+        "Peer Review",
+        "Scoring",
+        "Audit",
+        "Falsifiability",
+        "Research Tooling"
+      ],
+      "has_references": true,
       "has_templates": false,
       "has_scripts": false
     }
@@ -2561,6 +2631,40 @@
         "ops",
         "cost"
       ]
+    },
+    {
+      "id": "multimodal-review-loop",
+      "name": "Multimodal Review Loop",
+      "summary": "Build, red-team, and observe multimodal agent behavior before release.",
+      "description": "Use for vision, audio, or generation work that needs an explicit safety and evidence review loop.",
+      "roles": [
+        {
+          "id": "builder",
+          "title": "Multimodal Builder",
+          "bundle_id": "orchestra-multimodal-safety",
+          "goal": "Own model integration, modality handling, and measurable task quality."
+        },
+        {
+          "id": "safety",
+          "title": "Safety Reviewer",
+          "bundle_id": "orchestra-multimodal-safety",
+          "goal": "Exercise guardrails, adversarial inputs, and policy boundaries before release."
+        },
+        {
+          "id": "evidence",
+          "title": "Evidence Reviewer",
+          "bundle_id": "orchestra-research-foundation",
+          "goal": "Require reproducible evaluations, traces, and release evidence for every claim."
+        }
+      ],
+      "recommended_min_agents": 3,
+      "recommended_max_agents": 4,
+      "coordination_notes": "Do not ship a modality until quality, abuse resistance, and trace evidence pass independently.",
+      "tags": [
+        "multimodal",
+        "safety",
+        "evaluation"
+      ]
     }
   ],
   "templates": [
@@ -2612,11 +2716,11 @@
         "official-import"
       ],
       "category": "orchestra-research",
-      "version": "2026.04.10",
+      "version": "2026.06.15",
       "is_official": false,
       "source_path": "src/api/data/orchestra_research_catalog.json",
       "validation_status": "pinned",
-      "validation_message": "Pinned to Orchestra Research commit 05f1958727bfc2bc22240f41d060504473c4f236."
+      "validation_message": "Pinned to Orchestra Research v1.7.2 at commit 773a52944ba4747a18bd4ae9ade53fff041adcbc."
     },
     {
       "id": "orchestra_rag_lab",
@@ -2665,11 +2769,11 @@
         "grounding"
       ],
       "category": "orchestra-research",
-      "version": "2026.04.10",
+      "version": "2026.06.15",
       "is_official": false,
       "source_path": "src/api/data/orchestra_research_catalog.json",
       "validation_status": "pinned",
-      "validation_message": "Pinned to Orchestra Research commit 05f1958727bfc2bc22240f41d060504473c4f236."
+      "validation_message": "Pinned to Orchestra Research v1.7.2 at commit 773a52944ba4747a18bd4ae9ade53fff041adcbc."
     },
     {
       "id": "orchestra_post_training_lab",
@@ -2721,11 +2825,11 @@
         "fine-tuning"
       ],
       "category": "orchestra-research",
-      "version": "2026.04.10",
+      "version": "2026.06.15",
       "is_official": false,
       "source_path": "src/api/data/orchestra_research_catalog.json",
       "validation_status": "pinned",
-      "validation_message": "Pinned to Orchestra Research commit 05f1958727bfc2bc22240f41d060504473c4f236."
+      "validation_message": "Pinned to Orchestra Research v1.7.2 at commit 773a52944ba4747a18bd4ae9ade53fff041adcbc."
     },
     {
       "id": "orchestra_inference_lab",
@@ -2775,11 +2879,68 @@
         "optimization"
       ],
       "category": "orchestra-research",
-      "version": "2026.04.10",
+      "version": "2026.06.15",
       "is_official": false,
       "source_path": "src/api/data/orchestra_research_catalog.json",
       "validation_status": "pinned",
-      "validation_message": "Pinned to Orchestra Research commit 05f1958727bfc2bc22240f41d060504473c4f236."
+      "validation_message": "Pinned to Orchestra Research v1.7.2 at commit 773a52944ba4747a18bd4ae9ade53fff041adcbc."
+    },
+    {
+      "id": "orchestra_multimodal_guardrails",
+      "name": "Orchestra Multimodal Guardrails",
+      "summary": "Deploy a multimodal operator with safety, evaluation, and observability skills preloaded.",
+      "description": "Starter for vision, audio, and generation work that must pass explicit guardrail and trace review before release.",
+      "bundle_ids": [
+        "orchestra-multimodal-safety"
+      ],
+      "default_config": {
+        "name": "Orchestra Multimodal Guardrails",
+        "runtime": "personal_assistant",
+        "template": "orchestra_multimodal_guardrails",
+        "workspace": "orchestra-multimodal-guardrails",
+        "model": "openai/gpt-5",
+        "skills": [
+          "llava",
+          "blip-2",
+          "clip",
+          "whisper",
+          "constitutional-ai",
+          "llamaguard",
+          "prompt-guard",
+          "nemo-guardrails",
+          "langsmith",
+          "phoenix"
+        ],
+        "channels": {
+          "webchat": {
+            "label": "WebChat",
+            "enabled": true,
+            "mode": "pairing",
+            "allow_from": []
+          }
+        },
+        "metadata": {
+          "template": {
+            "kind": "orchestra-research",
+            "source": "orchestra-research",
+            "files": [
+              "src/api/data/orchestra_research_catalog.json"
+            ],
+            "source_template_id": null
+          }
+        }
+      },
+      "tags": [
+        "multimodal",
+        "safety",
+        "observability"
+      ],
+      "category": "orchestra-research",
+      "version": "2026.06.15",
+      "is_official": false,
+      "source_path": "src/api/data/orchestra_research_catalog.json",
+      "validation_status": "pinned",
+      "validation_message": "Pinned to Orchestra Research v1.7.2 at commit 773a52944ba4747a18bd4ae9ade53fff041adcbc."
     }
   ]
 }

--- a/tests/api/test_swarms.py
+++ b/tests/api/test_swarms.py
@@ -7,6 +7,15 @@ import pytest
 from httpx import AsyncClient
 
 
+@pytest.mark.asyncio
+async def test_list_blueprints_includes_multimodal_review_loop(client: AsyncClient):
+    response = await client.get("/v1/swarms/blueprints")
+
+    assert response.status_code == 200
+    blueprint_ids = {item["id"] for item in response.json()}
+    assert "multimodal-review-loop" in blueprint_ids
+
+
 class TestListSwarms:
     """Tests for GET /swarms endpoint."""
 

--- a/tests/api/test_templates_route.py
+++ b/tests/api/test_templates_route.py
@@ -39,6 +39,7 @@ async def test_list_templates_includes_orchestra_research_presets(client: AsyncC
     template_ids = {item["id"] for item in response.json()}
     assert "orchestra_research_foundation" in template_ids
     assert "orchestra_rag_lab" in template_ids
+    assert "orchestra_multimodal_guardrails" in template_ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_oss_attribution_contract.py
+++ b/tests/test_oss_attribution_contract.py
@@ -14,7 +14,7 @@ EVIDENCE_PATH = ROOT / "docs/legal/oss-attribution-evidence.json"
 def _projects() -> dict[str, dict[str, object]]:
     payload = json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))
     assert payload["schema_version"] == 1
-    assert payload["verified_at"] == "2026-07-15"
+    assert payload["verified_at"] == "2026-07-22"
     return {project["id"]: project for project in payload["projects"]}
 
 
@@ -112,6 +112,11 @@ def test_evidence_uses_immutable_source_and_license_links() -> None:
     assert faramesh["installer_license"] == "MPL-2.0"
     assert faramesh["installer_ref"] in faramesh["installer_source_url"]
     assert faramesh["installer_ref"] in faramesh["installer_license_url"]
+
+    orchestra = projects["orchestra-research"]
+    assert orchestra["status"] == "integrated-current"
+    assert orchestra["integration_version"] == "v1.7.2"
+    assert orchestra["integration_ref"] == orchestra["current_ref"]
 
 
 def test_required_apache_and_mpl_license_texts_are_verbatim() -> None:

--- a/tests/unit/python/test_orchestra_research_catalog.py
+++ b/tests/unit/python/test_orchestra_research_catalog.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.build_orchestra_research_catalog import (
+    DEFAULT_COMMIT,
+    DEFAULT_RELEASE,
+    build_catalog,
+    discover_skills,
+    validate_catalog,
+)
+from scripts.sync_orchestra_research_skills import DEFAULT_COMMIT as SYNC_COMMIT
+from scripts.sync_orchestra_research_skills import DEFAULT_RELEASE as SYNC_RELEASE
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CATALOG_PATH = ROOT / "src/api/data/orchestra_research_catalog.json"
+
+
+def test_discover_skills_normalizes_upstream_frontmatter(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "22-agent-native-research-artifact" / "compiler"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: ara-compiler
+description: Compile research into an agent-native artifact.
+author: Orchestra Research
+tags: [ARA, Provenance]
+---
+
+# Universal ARA Compiler
+""",
+        encoding="utf-8",
+    )
+
+    assert discover_skills(tmp_path) == [
+        {
+            "id": "compiler",
+            "canonical_name": "ara-compiler",
+            "name": "Universal ARA Compiler",
+            "description": "Compile research into an agent-native artifact.",
+            "author": "Orchestra Research",
+            "category_id": "22-agent-native-research-artifact",
+            "category_name": "Agent Native Research Artifact",
+            "upstream_path": "22-agent-native-research-artifact/compiler",
+            "tags": ["ARA", "Provenance"],
+            "has_references": True,
+            "has_templates": False,
+            "has_scripts": False,
+        }
+    ]
+
+
+def test_build_catalog_preserves_curated_layers_and_updates_template_pin() -> None:
+    existing = {
+        "bundles": [
+            {
+                "id": "foundation",
+                "skill_ids": ["compiler"],
+                "recommended_template_id": "template",
+                "recommended_swarm_blueprint_id": "blueprint",
+            }
+        ],
+        "swarm_blueprints": [{"id": "blueprint", "roles": [{"bundle_id": "foundation"}]}],
+        "templates": [
+            {
+                "id": "template",
+                "bundle_ids": ["foundation"],
+                "default_config": {"skills": ["compiler"]},
+                "version": "old",
+                "validation_message": "old",
+            }
+        ],
+    }
+    source = {
+        "version": DEFAULT_RELEASE,
+        "commit": DEFAULT_COMMIT,
+        "commit_date": "2026-06-15T21:36:40-04:00",
+    }
+    skills = [{"id": "compiler"}]
+
+    catalog = build_catalog(existing, source=source, skills=skills)
+
+    assert catalog["templates"][0]["version"] == "2026.06.15"
+    assert DEFAULT_RELEASE in catalog["templates"][0]["validation_message"]
+    assert DEFAULT_COMMIT in catalog["templates"][0]["validation_message"]
+    assert catalog["bundles"] == existing["bundles"]
+
+
+def test_validate_catalog_rejects_dangling_skill_reference() -> None:
+    with pytest.raises(ValueError, match="missing skills"):
+        validate_catalog(
+            {
+                "skills": [],
+                "bundles": [
+                    {
+                        "id": "broken",
+                        "skill_ids": ["missing"],
+                        "recommended_template_id": "template",
+                        "recommended_swarm_blueprint_id": "blueprint",
+                    }
+                ],
+                "templates": [{"id": "template", "bundle_ids": [], "default_config": {}}],
+                "swarm_blueprints": [{"id": "blueprint", "roles": []}],
+            }
+        )
+
+
+def test_checked_in_catalog_matches_v172_contract() -> None:
+    catalog = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    source = catalog["source"]
+    skill_ids = {skill["id"] for skill in catalog["skills"]}
+
+    assert source["version"] == DEFAULT_RELEASE == SYNC_RELEASE
+    assert source["commit"] == DEFAULT_COMMIT == SYNC_COMMIT
+    assert len(catalog["skills"]) == 98
+    assert {"compiler", "research-manager", "rigor-reviewer"} <= skill_ids
+    validate_catalog(catalog)


### PR DESCRIPTION
Part of #3688

## What changed

- advance the Orchestra Research integration from the historical `05f1958` pin to release `v1.7.2` at immutable commit `773a52944ba4747a18bd4ae9ade53fff041adcbc`
- add a deterministic catalog builder that reproduces the old 95-skill catalog exactly before applying upstream changes
- regenerate all 98 current skills, including the ARA compiler, live research manager, and rigor reviewer
- pin runtime sync to the same release and record version/commit in its manifest
- close the original catalog's dangling multimodal references with an executable starter template and swarm review loop
- update attribution evidence and operator documentation

No upstream skill content is vendored into first-party docs; metadata and runtime sync remain explicitly attributed.

## Upstream evidence

- release: https://github.com/Orchestra-Research/AI-Research-SKILLs/releases/tag/v1.7.2
- commit: https://github.com/Orchestra-Research/AI-Research-SKILLs/commit/773a52944ba4747a18bd4ae9ade53fff041adcbc
- license: https://github.com/Orchestra-Research/AI-Research-SKILLs/blob/773a52944ba4747a18bd4ae9ade53fff041adcbc/LICENSE

## Validation

- 39 focused catalog, attribution, template, swarm, and ClawHub tests passed
- deterministic catalog `--check` passed
- v1.7.2 runtime sync copied and recorded all 98 skills
- Ruff check/format, compileall, JSON validation, and diff check passed
