### PR TITLE
ci: make dormant Terraform drift schedule opt-in

### DIFF
--- a/.github/workflows/infrastructure-drift.yml
+++ b/.github/workflows/infrastructure-drift.yml
@@ -9,8 +9,25 @@ permissions:
   contents: read
 
 jobs:
+  readiness:
+    name: Terraform drift readiness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report drift schedule state
+        env:
+          ENABLE_TERRAFORM_DRIFT: ${{ vars.ENABLE_TERRAFORM_DRIFT }}
+          TRIGGER: ${{ github.event_name }}
+        run: |
+          if [ "$TRIGGER" = "schedule" ] && [ "$ENABLE_TERRAFORM_DRIFT" != "true" ]; then
+            echo "::notice::Scheduled Terraform drift is disabled. Set ENABLE_TERRAFORM_DRIFT=true after configuring the required cloud and remote-state credentials."
+          else
+            echo "Terraform drift was explicitly requested or enabled."
+          fi
+
   terraform-drift:
     name: Terraform drift (${{ matrix.environment }})
+    needs: readiness
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_TERRAFORM_DRIFT == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -88,17 +88,21 @@ The monitoring compose file binds UI and exporter ports to localhost by default.
 
 ## CI Drift Detection
 
-A scheduled GitHub Actions workflow now checks Terraform drift daily for both `staging` and `production` using `terraform plan -detailed-exitcode`:
+Railway is the current production deployment path. The Terraform DigitalOcean configuration remains an alternate deployment path and its drift workflow is intentionally dormant until real cloud and remote-state credentials are configured.
 
 * Workflow: `.github/workflows/infrastructure-drift.yml`
-* Trigger: daily cron + manual dispatch
-* Behavior: uploads plan artifacts and fails when drift is detected
+* Trigger: manual dispatch at any time; daily cron only when the repository variable `ENABLE_TERRAFORM_DRIFT` is set to `true`
+* Disabled schedule: reports readiness and skips the Terraform matrix instead of producing a false drift failure
+* Enabled behavior: uploads plan artifacts and fails when drift is detected
+* Manual safety: dispatch remains fail-closed when any required secret is missing
 
-Required GitHub secrets:
+Required GitHub secrets before enabling the schedule:
 
 * `DO_TOKEN`
 * `TF_STATE_ACCESS_KEY_ID`
 * `TF_STATE_SECRET_ACCESS_KEY`
+
+Prefer environment-scoped secrets and approvals for `staging` and `production` when this deployment path is activated.
 
 ## Extra Validation Targets
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -102,7 +102,10 @@ Required GitHub secrets before enabling the schedule:
 * `TF_STATE_ACCESS_KEY_ID`
 * `TF_STATE_SECRET_ACCESS_KEY`
 
-Prefer environment-scoped secrets and approvals for `staging` and `production` when this deployment path is activated.
+Store these as repository or organization Actions secrets. The workflow does not
+currently declare GitHub environments, so environment-scoped secrets are not
+available to its matrix jobs. If environments and approval gates are added later,
+update the workflow and this guidance together.
 
 ## Extra Validation Targets
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -86,17 +86,21 @@ Default monitoring URLs (when using `.env.monitoring.example` defaults):
 
 ## CI Drift Detection
 
-A scheduled GitHub Actions workflow now checks Terraform drift daily for both `staging` and `production` using `terraform plan -detailed-exitcode`:
+Railway is the current production deployment path. The Terraform DigitalOcean configuration remains an alternate deployment path and its drift workflow is intentionally dormant until real cloud and remote-state credentials are configured.
 
 - Workflow: `.github/workflows/infrastructure-drift.yml`
-- Trigger: daily cron + manual dispatch
-- Behavior: uploads plan artifacts and fails when drift is detected
+- Trigger: manual dispatch at any time; daily cron only when the repository variable `ENABLE_TERRAFORM_DRIFT` is set to `true`
+- Disabled schedule: reports readiness and skips the Terraform matrix instead of producing a false drift failure
+- Enabled behavior: uploads plan artifacts and fails when drift is detected
+- Manual safety: dispatch remains fail-closed when any required secret is missing
 
-Required GitHub secrets:
+Required GitHub secrets before enabling the schedule:
 
 - `DO_TOKEN`
 - `TF_STATE_ACCESS_KEY_ID`
 - `TF_STATE_SECRET_ACCESS_KEY`
+
+Prefer environment-scoped secrets and approvals for `staging` and `production` when this deployment path is activated.
 
 ## Extra Validation Targets
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -100,7 +100,10 @@ Required GitHub secrets before enabling the schedule:
 - `TF_STATE_ACCESS_KEY_ID`
 - `TF_STATE_SECRET_ACCESS_KEY`
 
-Prefer environment-scoped secrets and approvals for `staging` and `production` when this deployment path is activated.
+Store these as repository or organization Actions secrets. The workflow does not
+currently declare GitHub environments, so environment-scoped secrets are not
+available to its matrix jobs. If environments and approval gates are added later,
+update the workflow and this guidance together.
 
 ## Extra Validation Targets
 

--- a/tests/unit/python/test_infrastructure_drift_workflow.py
+++ b/tests/unit/python/test_infrastructure_drift_workflow.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def read_text(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_scheduled_terraform_drift_is_explicitly_opt_in() -> None:
+    workflow = read_text(".github/workflows/infrastructure-drift.yml")
+
+    assert "schedule:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "vars.ENABLE_TERRAFORM_DRIFT == 'true'" in workflow
+    assert "github.event_name == 'workflow_dispatch'" in workflow
+    assert "needs: readiness" in workflow
+    assert "Scheduled Terraform drift is disabled" in workflow
+
+
+def test_manual_drift_remains_fail_closed_before_terraform_setup() -> None:
+    workflow = read_text(".github/workflows/infrastructure-drift.yml")
+
+    validation = workflow.index("- name: Validate required secrets")
+    setup = workflow.index("- name: Set up Terraform")
+    init = workflow.index("- name: Terraform init (remote backend)")
+    plan = workflow.index("- name: Terraform plan (drift check)")
+
+    assert validation < setup < init < plan
+    assert "exit 1" in workflow[validation:setup]
+    for secret in (
+        "secrets.DO_TOKEN",
+        "secrets.TF_STATE_ACCESS_KEY_ID",
+        "secrets.TF_STATE_SECRET_ACCESS_KEY",
+    ):
+        assert secret in workflow
+
+
+def test_infrastructure_docs_describe_current_and_alternate_deployments() -> None:
+    for path in ("infrastructure/README.md", "docs/infrastructure.md"):
+        docs = read_text(path)
+        assert "Railway is the current production deployment path" in docs
+        assert "ENABLE_TERRAFORM_DRIFT" in docs
+        assert "dispatch remains fail-closed" in docs

--- a/tests/unit/python/test_infrastructure_drift_workflow.py
+++ b/tests/unit/python/test_infrastructure_drift_workflow.py
@@ -45,3 +45,5 @@ def test_infrastructure_docs_describe_current_and_alternate_deployments() -> Non
         assert "Railway is the current production deployment path" in docs
         assert "ENABLE_TERRAFORM_DRIFT" in docs
         assert "dispatch remains fail-closed" in docs
+        assert "repository or organization Actions secrets" in docs
+        assert "environment-scoped secrets are not" in docs


### PR DESCRIPTION
## Summary
- keep Terraform drift manually dispatchable and fail-closed
- gate the daily matrix behind `ENABLE_TERRAFORM_DRIFT=true`
- add an always-running readiness notice so disabled schedules are explicit, not silent
- correct both infrastructure docs: Railway is current production; DigitalOcean Terraform is an alternate dormant path
- add workflow contracts covering the schedule gate, secret validation order, and docs truth

## Root cause
The repository does not have `DO_TOKEN`, `TF_STATE_ACCESS_KEY_ID`, or `TF_STATE_SECRET_ACCESS_KEY`. The latest 100 scheduled runs all failed in credential validation before Terraform initialized, so the red history was configuration noise rather than drift detection.

Manual dispatch still bypasses only the schedule gate. Missing credentials continue to fail before setup/init/plan.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/infrastructure-drift.yml` — pass
- focused pytest — 3 passed
- Ruff check + format check — pass
- `git diff --check` — pass