### PR TITLE
feat(autonomy): enforce Mission Control v2.2.0 dispatch boundaries

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -87,13 +87,17 @@ distributed; the main-branch relicense does not retroactively change either tag.
 
 - **Repository:** https://github.com/builderz-labs/mission-control
 - **License:** MIT — Copyright (c) 2026 Builderz Labs
-- **Current upstream release:** `v2.1.0`
+- **Current upstream release:** `v2.2.0`
+  (`0552b00b3b743ed12949e6deb19597655b02bbcc`), verified 2026-07-22
+- **Comparison baseline:** `v2.1.0`
   (`b4ebc5418bea4fa9288a5c17fbddb9ba99740964`)
-- **MUTX use:** dashboard briefing and signal-display patterns.
+- **MUTX use:** dashboard briefing and signal-display patterns, plus an adapted
+  fail-closed autonomy-runner working-directory and change-scope contract.
 
 The direct adaptation is pinned to immutable upstream paths and the local port
-commit in the attribution ledger. The current upstream release is newer than
-that provenance pin; the two are intentionally reported separately.
+commit in the attribution ledger. The v2.2.0 dispatch contract is pinned to
+immutable source in the machine-readable evidence file; the historical UI
+provenance and current behavioral review are intentionally reported separately.
 
 ### Orchestra Research AI-Research-SKILLs
 

--- a/docs/legal/oss-attribution-evidence.json
+++ b/docs/legal/oss-attribution-evidence.json
@@ -100,19 +100,31 @@
       "repository": "https://github.com/builderz-labs/mission-control",
       "license": "MIT",
       "copyright": "Copyright (c) 2026 Builderz Labs",
-      "current_ref": "b4ebc5418bea4fa9288a5c17fbddb9ba99740964",
-      "current_version": "v2.1.0",
-      "release_url": "https://github.com/builderz-labs/mission-control/commit/b4ebc5418bea4fa9288a5c17fbddb9ba99740964",
-      "license_url": "https://github.com/builderz-labs/mission-control/blob/b4ebc5418bea4fa9288a5c17fbddb9ba99740964/LICENSE",
+      "verified_at": "2026-07-22",
+      "current_ref": "0552b00b3b743ed12949e6deb19597655b02bbcc",
+      "current_version": "v2.2.0",
+      "release_url": "https://github.com/builderz-labs/mission-control/commit/0552b00b3b743ed12949e6deb19597655b02bbcc",
+      "license_url": "https://github.com/builderz-labs/mission-control/blob/0552b00b3b743ed12949e6deb19597655b02bbcc/LICENSE",
+      "comparison_baseline_version": "v2.1.0",
+      "comparison_baseline_ref": "b4ebc5418bea4fa9288a5c17fbddb9ba99740964",
       "provenance_ref": "eb7c35e950b83f73d6fd61e89f7d4b377db2ad50",
       "source_urls": [
         "https://github.com/builderz-labs/mission-control/blob/eb7c35e950b83f73d6fd61e89f7d4b377db2ad50/src/components/dashboard/widgets/briefing-bar-widget.tsx",
         "https://github.com/builderz-labs/mission-control/blob/eb7c35e950b83f73d6fd61e89f7d4b377db2ad50/src/components/dashboard/widget-primitives.tsx"
       ],
       "local_port_commit": "972ab49b0af83d15042b2301679246103cbdbab6",
+      "reviewed_contract_source_urls": [
+        "https://github.com/builderz-labs/mission-control/blob/0552b00b3b743ed12949e6deb19597655b02bbcc/src/lib/task-dispatch.ts",
+        "https://github.com/builderz-labs/mission-control/blob/0552b00b3b743ed12949e6deb19597655b02bbcc/src/lib/__tests__/task-dispatch-sandbox.test.ts"
+      ],
       "local_paths": [
         "components/dashboard/DashboardOverviewPageClient.tsx",
-        "components/dashboard/livePrimitives.tsx"
+        "components/dashboard/livePrimitives.tsx",
+        "scripts/autonomy/work_order_sandbox.py",
+        "scripts/autonomy/run_codex_lane.py",
+        "scripts/autonomy/run_opencode_lane.py",
+        "scripts/autonomy/run_main_lane.py",
+        "tests/test_autonomy_work_order_sandbox.py"
       ]
     },
     {

--- a/docs/upstream-dep-report.md
+++ b/docs/upstream-dep-report.md
@@ -1,6 +1,6 @@
 # MUTX upstream dependency report
 
-Last verified: 2026-07-15
+Full inventory last verified: 2026-07-15. Mission Control re-verified: 2026-07-22.
 
 This report separates three facts that older revisions conflated:
 
@@ -19,7 +19,7 @@ Immutable license and source evidence is maintained in
 | AARM docs | Main `8eff208b98786b2c9a578b26cb7eaca440ec4020` | MIT, Copyright (c) 2023 Mintlify | MUTX’s old R1–R9 numbering drifted from the current model | Use the current mapping; close technical and organizational gaps before any conformance claim |
 | Faramesh Core | Main `e230a9ac2d12d80ed6f632db42b6e1983ccbce82`; pinned published release `v0.2.0` / `ae3ebc9066d65e4e930164881c2f2ce2be554c7f`; historical semver tag `v1.2.9` / `c85237e4e6b13745169291f60b9c6b985285dbaa` | Main: Apache-2.0; `v0.2.0` and `v1.2.9`: MPL-2.0 | CLI and gateway fetch an immutable installer and request `v0.2.0` explicitly | Run the pinned compatibility lane before changing either installer ref or release |
 | FPL | Main `b7aa0b7ad56f60428d692278a435c5e6640cec2b` | Apache-2.0 | MUTX ships FPL policy files and CLI integration | Validate parser/daemon compatibility; retain Apache-2.0 text and any future `NOTICE` |
-| Mission Control | `v2.1.0` / `b4ebc5418bea4fa9288a5c17fbddb9ba99740964` | MIT, Copyright (c) 2026 Builderz Labs | Direct dashboard pattern provenance predates the current release | Treat `v2.1.0` as the comparison baseline, not proof of compatibility |
+| Mission Control | `v2.2.0` / `0552b00b3b743ed12949e6deb19597655b02bbcc` | MIT, Copyright (c) 2026 Builderz Labs | Historical dashboard provenance remains pinned; v2.2.0's dispatch-boundary contract is adapted and tested locally | Keep `v2.1.0` as the behavioral comparison baseline and review future releases against the enforced runner boundary |
 | Orchestra Research AI-Research-SKILLs | `v1.7.2` / `773a52944ba4747a18bd4ae9ade53fff041adcbc` | MIT, Copyright (c) 2025 Claude AI Research Skills Contributors | Catalog is pinned to `05f1958727bfc2bc22240f41d060504473c4f236` | Regenerate and validate the catalog against `v1.7.2` in a dedicated migration |
 | predict-rlm | `v0.7.2` / `4ff334dea79a2f27e96b7a50a358b0427050899e` | MIT, Copyright (c) 2026 Trampoline AI | Workflow provenance is pinned to `5c7387afa1980b62b21a34ad0261256a95d8caa1` | Validate templates, runtime prerequisites, and output contracts against `v0.7.2` |
 | Guild AI | Tag `0.9.0`; audited main `dfbefedb6ca5ce3a1341f9f00a4016420f6fc76d` | Apache-2.0 | Candidate only; no direct reuse recorded | Keep out of the distribution unless a scoped adoption decision records exact provenance |
@@ -65,11 +65,40 @@ evidence satisfying those conditions. See
 
 ## Mission Control comparison baseline
 
-Mission Control `v2.1.0` supersedes the `v2.0.1` baseline used by the previous
-report. MUTX should compare behavior rather than copy its API breadth wholesale.
-The durable direct-port evidence is intentionally pinned to the upstream source
-commit that introduced the briefing pattern and to MUTX port commit
+Mission Control `v2.2.0` is pinned at
+[`0552b00b`](https://github.com/builderz-labs/mission-control/commit/0552b00b3b743ed12949e6deb19597655b02bbcc),
+with `v2.1.0` / `b4ebc5418bea4fa9288a5c17fbddb9ba99740964`
+retained as the comparison baseline. MUTX compares behavior rather than copying
+Mission Control's API breadth wholesale. The historical dashboard port remains
+pinned to upstream source commit
+`eb7c35e950b83f73d6fd61e89f7d4b377db2ad50`, which introduced the briefing
+pattern, and to MUTX port commit
 `972ab49b0af83d15042b2301679246103cbdbab6`.
+
+The v2.2.0 release adds strict workspace isolation and a host-CLI dispatch
+sandbox. The directly applicable contract is the
+[`task-dispatch.ts`](https://github.com/builderz-labs/mission-control/blob/0552b00b3b743ed12949e6deb19597655b02bbcc/src/lib/task-dispatch.ts)
+realpath-confined working directory and clamped execution-boundary design. MUTX
+adapts that contract to its repository-native autonomous lanes:
+
+- every runner resolves the exact Git worktree root before dispatch;
+- declared path scopes reject traversal, `.git`, and symlink escapes;
+- a dirty worktree blocks execution before an agent process starts;
+- post-worker and post-verification changes outside `allowed_paths`, or above
+  the clamped `max_changed_files` limit, fail closed before publication;
+- rename checks inspect both the old and new paths; and
+- the pre-dispatch commit is pinned, so worker-created commits cannot hide
+  changes or bypass the orchestrator-owned publication step.
+
+The implementation lives in `scripts/autonomy/work_order_sandbox.py` and is
+enforced by the Codex, OpenCode, and main-lane runners. Focused regression
+coverage lives in `tests/test_autonomy_work_order_sandbox.py`.
+
+The broader upstream workspace database model, host-administration routes,
+gateway registry, and filesystem API are not copied: MUTX uses a different
+authenticated FastAPI control plane and resource ownership model. The two
+historically adapted briefing components changed only Tailwind utility names in
+v2.2.0, so there is no behavioral dashboard delta to port from this release.
 
 High-value comparison areas remain:
 
@@ -100,9 +129,20 @@ MUTX conformance.
 3. Validate the pinned Faramesh Core `v0.2.0` release and current FPL in an isolated compatibility lane.
 4. Regenerate Orchestra metadata against `v1.7.2` and review the resulting content.
 5. Exercise predict-rlm `v0.7.2` through every managed/local workflow contract.
-6. Re-audit Mission Control `v2.1.0` only for roadmap-backed capabilities.
+6. Keep Mission Control's v2.2.0 runner-boundary adaptation covered while
+   reviewing later releases only for roadmap-backed behavioral contracts.
 
 ## Changelog
+
+### 2026-07-22
+
+- Verified Mission Control `v2.2.0` at immutable commit
+  `0552b00b3b743ed12949e6deb19597655b02bbcc` and retained `v2.1.0` as the
+  explicit comparison baseline.
+- Adapted its host-CLI working-directory and bounded-dispatch contract to all
+  MUTX autonomy runners with fail-closed path and change-count checks.
+- Confirmed the historical briefing port has no applicable v2.2.0 behavioral
+  delta; its immutable source and local-port provenance remain unchanged.
 
 ### 2026-07-15
 

--- a/scripts/autonomy/run_codex_lane.py
+++ b/scripts/autonomy/run_codex_lane.py
@@ -8,6 +8,13 @@ from pathlib import Path
 from typing import Any
 
 from failure_classifier import classify_failure, extract_retry_after_seconds
+from work_order_sandbox import (
+    SANDBOX_BLOCKER_CLASS,
+    WorkOrderSandboxError,
+    assess_worktree_changes,
+    list_changed_files,
+    prepare_work_order_sandbox,
+)
 
 
 DEFAULT_MODEL = "gpt-5.4"
@@ -23,25 +30,25 @@ def build_prompt(work_order: dict[str, Any]) -> str:
     constraints = "\n".join(f"- {item}" for item in work_order.get("constraints", []))
     return f"""You are the Codex backend worker for MUTX.
 
-Task ID: {work_order['id']}
-Title: {work_order['title']}
-Lane: {work_order['lane']}
-Worktree: {work_order['worktree']}
+Task ID: {work_order["id"]}
+Title: {work_order["title"]}
+Lane: {work_order["lane"]}
+Worktree: {work_order["worktree"]}
 
 Description:
-{work_order['description']}
+{work_order["description"]}
 
 Allowed paths:
-{allowed_paths or '- (none declared)'}
+{allowed_paths or "- (none declared)"}
 
 Verification commands:
-{verification or '- (none declared)'}
+{verification or "- (none declared)"}
 
 Constraints:
-{constraints or '- keep the change small and focused'}
+{constraints or "- keep the change small and focused"}
 
 Execution rules:
-- Stay inside the allowed paths unless you must touch one tiny linked dependency file.
+- Stay strictly inside the allowed paths; the runner enforces this boundary after execution.
 - Prefer the smallest correct backend change.
 - Do not mutate queue state.
 - Do not edit scheduling or orchestration policy.
@@ -68,15 +75,7 @@ def run_command(command: list[str], timeout: int) -> subprocess.CompletedProcess
 
 
 def changed_files(cwd: str) -> list[str]:
-    result = subprocess.run(["git", "status", "--short"], cwd=cwd, text=True, capture_output=True)
-    if result.returncode != 0:
-        return []
-    files = []
-    for line in result.stdout.splitlines():
-        if not line.strip():
-            continue
-        files.append(line[3:] if len(line) > 3 else line)
-    return files
+    return list_changed_files(cwd)
 
 
 def run_verification(commands: list[str], cwd: str) -> list[dict[str, Any]]:
@@ -84,7 +83,9 @@ def run_verification(commands: list[str], cwd: str) -> list[dict[str, Any]]:
     for command in commands:
         argv = shlex.split(command)
         if not argv:
-            results.append({"command": command, "exit_code": 2, "stdout": "", "stderr": "empty command"})
+            results.append(
+                {"command": command, "exit_code": 2, "stdout": "", "stderr": "empty command"}
+            )
             continue
         proc = subprocess.run(argv, cwd=cwd, text=True, capture_output=True, shell=False)
         results.append(
@@ -122,24 +123,62 @@ def main() -> int:
         print(json.dumps(preview, indent=2, sort_keys=True))
         return 0
 
+    try:
+        sandbox = prepare_work_order_sandbox(work_order)
+    except WorkOrderSandboxError as exc:
+        payload = {
+            **preview,
+            "exit_code": 2,
+            "stdout": "",
+            "stderr": exc.detail,
+            "changed_files": exc.context.get("changed_files", []),
+            "verification": [],
+            "verification_passed": False,
+            "blocker_class": SANDBOX_BLOCKER_CLASS,
+            "retry_after_seconds": None,
+            "sandbox": exc.to_dict(),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 2
+
+    work_order["worktree"] = sandbox.worktree
+    command = build_command(work_order, args.model)
+    preview["worktree"] = sandbox.worktree
+    preview["command"] = shlex.join(command)
     result = run_command(command, timeout=args.timeout)
-    verification = run_verification(work_order.get("verification", []), work_order["worktree"])
+    sandbox_result = assess_worktree_changes(sandbox)
+    verification = (
+        run_verification(work_order.get("verification", []), sandbox.worktree)
+        if sandbox_result["ok"]
+        else []
+    )
+    if sandbox_result["ok"]:
+        sandbox_result = assess_worktree_changes(sandbox)
+    sandbox_passed = bool(sandbox_result["ok"])
     combined_output = (result.stdout or "") + "\n" + (result.stderr or "")
-    blocker_class = classify_failure(combined_output)
+    blocker_class = classify_failure(combined_output) if sandbox_passed else SANDBOX_BLOCKER_CLASS
     retry_after_seconds = extract_retry_after_seconds(combined_output)
+    verification_passed = sandbox_passed and (
+        all(item["exit_code"] == 0 for item in verification) if verification else True
+    )
     payload = {
         **preview,
         "exit_code": result.returncode,
         "stdout": result.stdout,
         "stderr": result.stderr,
-        "changed_files": changed_files(work_order["worktree"]),
+        "changed_files": sandbox_result["changed_files"],
         "verification": verification,
-        "verification_passed": all(item["exit_code"] == 0 for item in verification) if verification else True,
+        "verification_passed": verification_passed,
         "blocker_class": blocker_class,
         "retry_after_seconds": retry_after_seconds,
+        "sandbox": sandbox_result,
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
-    return result.returncode if result.returncode != 0 else (0 if payload["verification_passed"] else 2)
+    return (
+        result.returncode
+        if result.returncode != 0
+        else (0 if payload["verification_passed"] else 2)
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/autonomy/run_main_lane.py
+++ b/scripts/autonomy/run_main_lane.py
@@ -8,6 +8,13 @@ from pathlib import Path
 from typing import Any
 
 from failure_classifier import classify_failure, extract_retry_after_seconds
+from work_order_sandbox import (
+    SANDBOX_BLOCKER_CLASS,
+    WorkOrderSandboxError,
+    assess_worktree_changes,
+    list_changed_files,
+    prepare_work_order_sandbox,
+)
 
 DEFAULT_MODEL = "minimax/MiniMax-M2.7"
 DOC_PREFIXES = ("docs/", "README.md", "docs/whitepaper.md", "docs/roadmap.md", "AGENTS.md")
@@ -22,7 +29,10 @@ def is_docs_task(work_order: dict[str, Any]) -> bool:
     if area == "docs":
         return True
     allowed = [str(path) for path in work_order.get("allowed_paths", [])]
-    return bool(allowed) and all(any(path == prefix or path.startswith(prefix) for prefix in DOC_PREFIXES) for path in allowed)
+    return bool(allowed) and all(
+        any(path == prefix or path.startswith(prefix) for prefix in DOC_PREFIXES)
+        for path in allowed
+    )
 
 
 def build_prompt(work_order: dict[str, Any]) -> str:
@@ -32,23 +42,23 @@ def build_prompt(work_order: dict[str, Any]) -> str:
     mode = "docs/truth" if is_docs_task(work_order) else "control-plane"
     return f"""You are the main orchestration lane worker for MUTX.
 
-Task ID: {work_order['id']}
-Title: {work_order['title']}
-Lane: {work_order['lane']}
+Task ID: {work_order["id"]}
+Title: {work_order["title"]}
+Lane: {work_order["lane"]}
 Mode: {mode}
-Worktree: {work_order['worktree']}
+Worktree: {work_order["worktree"]}
 
 Description:
-{work_order['description']}
+{work_order["description"]}
 
 Allowed paths:
-{allowed_paths or '- (none declared)'}
+{allowed_paths or "- (none declared)"}
 
 Verification commands:
-{verification or '- (none declared)'}
+{verification or "- (none declared)"}
 
 Constraints:
-{constraints or '- keep the change small and focused'}
+{constraints or "- keep the change small and focused"}
 
 Execution rules:
 - Be professional and conservative.
@@ -70,15 +80,7 @@ def run_command(command: list[str], cwd: str, timeout: int) -> subprocess.Comple
 
 
 def changed_files(cwd: str) -> list[str]:
-    result = subprocess.run(["git", "status", "--short"], cwd=cwd, text=True, capture_output=True)
-    if result.returncode != 0:
-        return []
-    files = []
-    for line in result.stdout.splitlines():
-        if not line.strip():
-            continue
-        files.append(line[3:] if len(line) > 3 else line)
-    return files
+    return list_changed_files(cwd)
 
 
 def run_verification(commands: list[str], cwd: str) -> list[dict[str, Any]]:
@@ -86,7 +88,9 @@ def run_verification(commands: list[str], cwd: str) -> list[dict[str, Any]]:
     for command in commands:
         argv = shlex.split(command)
         if not argv:
-            results.append({"command": command, "exit_code": 2, "stdout": "", "stderr": "empty command"})
+            results.append(
+                {"command": command, "exit_code": 2, "stdout": "", "stderr": "empty command"}
+            )
             continue
         proc = subprocess.run(argv, cwd=cwd, text=True, capture_output=True, shell=False)
         results.append(
@@ -105,7 +109,9 @@ def main() -> int:
     parser.add_argument("work_order", help="Path to normalized work-order JSON")
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument("--timeout", type=int, default=1800)
-    parser.add_argument("--execute", action="store_true", help="Actually invoke the main lane worker")
+    parser.add_argument(
+        "--execute", action="store_true", help="Actually invoke the main lane worker"
+    )
     args = parser.parse_args()
 
     work_order = load_work_order(args.work_order)
@@ -124,24 +130,62 @@ def main() -> int:
         print(json.dumps(preview, indent=2, sort_keys=True))
         return 0
 
-    result = run_command(command, cwd=work_order["worktree"], timeout=args.timeout)
-    verification = run_verification(work_order.get("verification", []), work_order["worktree"])
+    try:
+        sandbox = prepare_work_order_sandbox(work_order)
+    except WorkOrderSandboxError as exc:
+        payload = {
+            **preview,
+            "exit_code": 2,
+            "stdout": "",
+            "stderr": exc.detail,
+            "changed_files": exc.context.get("changed_files", []),
+            "verification": [],
+            "verification_passed": False,
+            "blocker_class": SANDBOX_BLOCKER_CLASS,
+            "retry_after_seconds": None,
+            "sandbox": exc.to_dict(),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 2
+
+    work_order["worktree"] = sandbox.worktree
+    command = build_command(work_order, args.model)
+    preview["worktree"] = sandbox.worktree
+    preview["command"] = shlex.join(command)
+    result = run_command(command, cwd=sandbox.worktree, timeout=args.timeout)
+    sandbox_result = assess_worktree_changes(sandbox)
+    verification = (
+        run_verification(work_order.get("verification", []), sandbox.worktree)
+        if sandbox_result["ok"]
+        else []
+    )
+    if sandbox_result["ok"]:
+        sandbox_result = assess_worktree_changes(sandbox)
+    sandbox_passed = bool(sandbox_result["ok"])
     combined_output = (result.stdout or "") + "\n" + (result.stderr or "")
-    blocker_class = classify_failure(combined_output)
+    blocker_class = classify_failure(combined_output) if sandbox_passed else SANDBOX_BLOCKER_CLASS
     retry_after_seconds = extract_retry_after_seconds(combined_output)
+    verification_passed = sandbox_passed and (
+        all(item["exit_code"] == 0 for item in verification) if verification else True
+    )
     payload = {
         **preview,
         "exit_code": result.returncode,
         "stdout": result.stdout,
         "stderr": result.stderr,
-        "changed_files": changed_files(work_order["worktree"]),
+        "changed_files": sandbox_result["changed_files"],
         "verification": verification,
-        "verification_passed": all(item["exit_code"] == 0 for item in verification) if verification else True,
+        "verification_passed": verification_passed,
         "blocker_class": blocker_class,
         "retry_after_seconds": retry_after_seconds,
+        "sandbox": sandbox_result,
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
-    return result.returncode if result.returncode != 0 else (0 if payload["verification_passed"] else 2)
+    return (
+        result.returncode
+        if result.returncode != 0
+        else (0 if payload["verification_passed"] else 2)
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/autonomy/run_opencode_lane.py
+++ b/scripts/autonomy/run_opencode_lane.py
@@ -8,6 +8,13 @@ from pathlib import Path
 from typing import Any
 
 from failure_classifier import classify_failure, extract_retry_after_seconds
+from work_order_sandbox import (
+    SANDBOX_BLOCKER_CLASS,
+    WorkOrderSandboxError,
+    assess_worktree_changes,
+    list_changed_files,
+    prepare_work_order_sandbox,
+)
 
 
 DEFAULT_MODEL = "minimax/MiniMax-M2.7"
@@ -23,25 +30,25 @@ def build_prompt(work_order: dict[str, Any]) -> str:
     constraints = "\n".join(f"- {item}" for item in work_order.get("constraints", []))
     return f"""You are the OpenCode frontend worker for MUTX.
 
-Task ID: {work_order['id']}
-Title: {work_order['title']}
-Lane: {work_order['lane']}
-Worktree: {work_order['worktree']}
+Task ID: {work_order["id"]}
+Title: {work_order["title"]}
+Lane: {work_order["lane"]}
+Worktree: {work_order["worktree"]}
 
 Description:
-{work_order['description']}
+{work_order["description"]}
 
 Allowed paths:
-{allowed_paths or '- (none declared)'}
+{allowed_paths or "- (none declared)"}
 
 Verification commands:
-{verification or '- (none declared)'}
+{verification or "- (none declared)"}
 
 Constraints:
-{constraints or '- keep the change small and focused'}
+{constraints or "- keep the change small and focused"}
 
 Execution rules:
-- Stay inside the allowed paths unless you must touch one tiny dependency file.
+- Stay strictly inside the allowed paths; the runner enforces this boundary after execution.
 - Keep edits minimal and production-minded.
 - Do not mutate queue state.
 - Do not edit scheduling or orchestration policy.
@@ -64,15 +71,7 @@ def run_command(command: list[str], cwd: str, timeout: int) -> subprocess.Comple
 
 
 def changed_files(cwd: str) -> list[str]:
-    result = subprocess.run(["git", "status", "--short"], cwd=cwd, text=True, capture_output=True)
-    if result.returncode != 0:
-        return []
-    files = []
-    for line in result.stdout.splitlines():
-        if not line.strip():
-            continue
-        files.append(line[3:] if len(line) > 3 else line)
-    return files
+    return list_changed_files(cwd)
 
 
 def run_verification(commands: list[str], cwd: str) -> list[dict[str, Any]]:
@@ -80,7 +79,9 @@ def run_verification(commands: list[str], cwd: str) -> list[dict[str, Any]]:
     for command in commands:
         argv = shlex.split(command)
         if not argv:
-            results.append({"command": command, "exit_code": 2, "stdout": "", "stderr": "empty command"})
+            results.append(
+                {"command": command, "exit_code": 2, "stdout": "", "stderr": "empty command"}
+            )
             continue
         proc = subprocess.run(argv, cwd=cwd, text=True, capture_output=True, shell=False)
         results.append(
@@ -92,7 +93,6 @@ def run_verification(commands: list[str], cwd: str) -> list[dict[str, Any]]:
             }
         )
     return results
-
 
 
 FALLBACK_MODELS = ["minimax/MiniMax-M2.7"]
@@ -114,9 +114,13 @@ def verify_changed_ts_syntax(repo_root: str, changed: list[str]) -> list[dict]:
         return []
     ts_path = __import__("pathlib").Path(repo_root) / "node_modules" / "typescript"
     if not ts_path.is_dir():
-        return [{"file": f, "exit_code": 0, "stdout": '{"ok": true}', "stderr": ""} for f in ts_files]
+        return [
+            {"file": f, "exit_code": 0, "stdout": '{"ok": true}', "stderr": ""} for f in ts_files
+        ]
 
-    import subprocess, json
+    import json
+    import subprocess
+
     node_check_script = (
         "const ts = require(String(process.argv[1]));"
         "const files = JSON.parse(String(process.argv[2]));"
@@ -151,15 +155,17 @@ def verify_changed_ts_syntax(repo_root: str, changed: list[str]) -> list[dict]:
     )
     try:
         proc = subprocess.run(
-            ["node", "-e", node_check_script, "--", str(ts_path),
-             json.dumps(ts_files), repo_root],
-            capture_output=True, text=True, timeout=30,
+            ["node", "-e", node_check_script, "--", str(ts_path), json.dumps(ts_files), repo_root],
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if proc.returncode == 0 and proc.stdout.strip():
             return json.loads(proc.stdout.strip())
     except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
         pass
     return [{"file": f, "exit_code": 0, "stdout": '{"ok": true}', "stderr": ""} for f in ts_files]
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run or preview the MUTX OpenCode lane")
@@ -185,24 +191,62 @@ def main() -> int:
         print(json.dumps(preview, indent=2, sort_keys=True))
         return 0
 
-    result = run_command(command, cwd=work_order["worktree"], timeout=args.timeout)
-    verification = run_verification(work_order.get("verification", []), work_order["worktree"])
+    try:
+        sandbox = prepare_work_order_sandbox(work_order)
+    except WorkOrderSandboxError as exc:
+        payload = {
+            **preview,
+            "exit_code": 2,
+            "stdout": "",
+            "stderr": exc.detail,
+            "changed_files": exc.context.get("changed_files", []),
+            "verification": [],
+            "verification_passed": False,
+            "blocker_class": SANDBOX_BLOCKER_CLASS,
+            "retry_after_seconds": None,
+            "sandbox": exc.to_dict(),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 2
+
+    work_order["worktree"] = sandbox.worktree
+    command = build_command(work_order, args.model)
+    preview["worktree"] = sandbox.worktree
+    preview["command"] = shlex.join(command)
+    result = run_command(command, cwd=sandbox.worktree, timeout=args.timeout)
+    sandbox_result = assess_worktree_changes(sandbox)
+    verification = (
+        run_verification(work_order.get("verification", []), sandbox.worktree)
+        if sandbox_result["ok"]
+        else []
+    )
+    if sandbox_result["ok"]:
+        sandbox_result = assess_worktree_changes(sandbox)
+    sandbox_passed = bool(sandbox_result["ok"])
     combined_output = (result.stdout or "") + "\n" + (result.stderr or "")
-    blocker_class = classify_failure(combined_output)
+    blocker_class = classify_failure(combined_output) if sandbox_passed else SANDBOX_BLOCKER_CLASS
     retry_after_seconds = extract_retry_after_seconds(combined_output)
+    verification_passed = sandbox_passed and (
+        all(item["exit_code"] == 0 for item in verification) if verification else True
+    )
     payload = {
         **preview,
         "exit_code": result.returncode,
         "stdout": result.stdout,
         "stderr": result.stderr,
-        "changed_files": changed_files(work_order["worktree"]),
+        "changed_files": sandbox_result["changed_files"],
         "verification": verification,
-        "verification_passed": all(item["exit_code"] == 0 for item in verification) if verification else True,
+        "verification_passed": verification_passed,
         "blocker_class": blocker_class,
         "retry_after_seconds": retry_after_seconds,
+        "sandbox": sandbox_result,
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
-    return result.returncode if result.returncode != 0 else (0 if payload["verification_passed"] else 2)
+    return (
+        result.returncode
+        if result.returncode != 0
+        else (0 if payload["verification_passed"] else 2)
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/autonomy/run_opencode_lane.py
+++ b/scripts/autonomy/run_opencode_lane.py
@@ -118,9 +118,6 @@ def verify_changed_ts_syntax(repo_root: str, changed: list[str]) -> list[dict]:
             {"file": f, "exit_code": 0, "stdout": '{"ok": true}', "stderr": ""} for f in ts_files
         ]
 
-    import json
-    import subprocess
-
     node_check_script = (
         "const ts = require(String(process.argv[1]));"
         "const files = JSON.parse(String(process.argv[2]));"

--- a/scripts/autonomy/work_order_sandbox.py
+++ b/scripts/autonomy/work_order_sandbox.py
@@ -1,0 +1,310 @@
+"""Fail-closed filesystem boundaries for autonomous work orders.
+
+The contract is adapted from Mission Control v2.2.0's host-CLI dispatch
+sandbox: resolve the execution directory through ``realpath``, keep it inside
+the declared workspace, and clamp task-controlled limits before dispatch.
+
+Upstream source (MIT, Copyright (c) 2026 Builderz Labs):
+https://github.com/builderz-labs/mission-control/blob/0552b00b3b743ed12949e6deb19597655b02bbcc/src/lib/task-dispatch.ts
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+
+DEFAULT_MAX_CHANGED_FILES = 6
+MAX_CHANGED_FILES_CEILING = 25
+SANDBOX_BLOCKER_CLASS = "sandbox_violation"
+_MAX_CHANGED_FILES = re.compile(r"^max_changed_files\s*=\s*(.+)$", re.IGNORECASE)
+
+
+class WorkOrderSandboxError(ValueError):
+    """A work order cannot be executed inside the declared boundary."""
+
+    def __init__(self, reason: str, detail: str, **context: Any) -> None:
+        super().__init__(detail)
+        self.reason = reason
+        self.detail = detail
+        self.context = context
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "reason": self.reason,
+            "detail": self.detail,
+            **self.context,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WorkOrderSandbox:
+    """Validated execution boundary for one autonomous worker."""
+
+    worktree: str
+    base_commit: str
+    allowed_paths: tuple[str, ...]
+    max_changed_files: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "worktree": self.worktree,
+            "base_commit": self.base_commit,
+            "allowed_paths": list(self.allowed_paths),
+            "max_changed_files": self.max_changed_files,
+        }
+
+
+def _run_git(worktree: str | Path, args: list[str]) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(worktree),
+        capture_output=True,
+        check=False,
+    )
+
+
+def resolve_git_worktree(raw_path: object) -> Path:
+    """Resolve an exact Git worktree root, rejecting subdirectories and missing paths."""
+
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise WorkOrderSandboxError("invalid_worktree", "Worktree must be a non-empty path")
+
+    candidate = Path(raw_path).expanduser()
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise WorkOrderSandboxError(
+            "invalid_worktree",
+            "Worktree does not exist or cannot be resolved",
+            worktree=raw_path,
+        ) from exc
+    if not resolved.is_dir():
+        raise WorkOrderSandboxError(
+            "invalid_worktree", "Worktree is not a directory", worktree=str(resolved)
+        )
+
+    top_level = _run_git(resolved, ["rev-parse", "--show-toplevel"])
+    if top_level.returncode != 0:
+        raise WorkOrderSandboxError(
+            "invalid_worktree", "Worktree is not a Git checkout", worktree=str(resolved)
+        )
+    try:
+        git_root = Path(top_level.stdout.decode().strip()).resolve(strict=True)
+    except (OSError, UnicodeDecodeError) as exc:
+        raise WorkOrderSandboxError(
+            "invalid_worktree", "Git worktree root cannot be resolved", worktree=str(resolved)
+        ) from exc
+    if git_root != resolved:
+        raise WorkOrderSandboxError(
+            "worktree_not_root",
+            "Execution must start at the exact Git worktree root",
+            worktree=str(resolved),
+            git_root=str(git_root),
+        )
+    return resolved
+
+
+def _normalize_allowed_path(raw_path: object, worktree: Path) -> str:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise WorkOrderSandboxError(
+            "invalid_allowed_path", "Allowed paths must be non-empty strings"
+        )
+
+    raw = raw_path.strip().rstrip("/")
+    raw_parts = raw.split("/")
+    parsed = PurePosixPath(raw)
+    if (
+        not raw
+        or raw == "."
+        or parsed.is_absolute()
+        or "\\" in raw
+        or "\x00" in raw
+        or any(part in {"", ".", "..", ".git"} for part in raw_parts)
+    ):
+        raise WorkOrderSandboxError(
+            "invalid_allowed_path",
+            "Allowed paths must be repository-relative and cannot traverse or target .git",
+            allowed_path=raw_path,
+        )
+
+    normalized = parsed.as_posix()
+    resolved_target = (worktree / normalized).resolve(strict=False)
+    if not resolved_target.is_relative_to(worktree):
+        raise WorkOrderSandboxError(
+            "allowed_path_escape",
+            "Allowed path resolves outside the worktree",
+            allowed_path=normalized,
+        )
+    return normalized
+
+
+def normalize_allowed_paths(raw_paths: object, worktree: Path) -> tuple[str, ...]:
+    """Validate and deduplicate repository-relative path prefixes."""
+
+    if not isinstance(raw_paths, list) or not raw_paths:
+        raise WorkOrderSandboxError(
+            "missing_allowed_paths", "At least one allowed path is required"
+        )
+    normalized = tuple(dict.fromkeys(_normalize_allowed_path(path, worktree) for path in raw_paths))
+    if not normalized:
+        raise WorkOrderSandboxError(
+            "missing_allowed_paths", "At least one allowed path is required"
+        )
+    return normalized
+
+
+def max_changed_files_from_constraints(raw_constraints: object) -> int:
+    """Read and clamp ``max_changed_files`` from untrusted work-order constraints."""
+
+    if raw_constraints is None:
+        return DEFAULT_MAX_CHANGED_FILES
+    if not isinstance(raw_constraints, list):
+        raise WorkOrderSandboxError("invalid_constraints", "Work-order constraints must be a list")
+
+    requested_limits: list[int] = []
+    for constraint in raw_constraints:
+        if not isinstance(constraint, str):
+            raise WorkOrderSandboxError(
+                "invalid_constraints", "Every work-order constraint must be a string"
+            )
+        match = _MAX_CHANGED_FILES.fullmatch(constraint.strip())
+        if not match:
+            continue
+        try:
+            requested = int(match.group(1))
+        except ValueError as exc:
+            raise WorkOrderSandboxError(
+                "invalid_changed_file_limit",
+                "max_changed_files must be a positive integer",
+                constraint=constraint,
+            ) from exc
+        if requested <= 0:
+            raise WorkOrderSandboxError(
+                "invalid_changed_file_limit",
+                "max_changed_files must be a positive integer",
+                constraint=constraint,
+            )
+        requested_limits.append(min(requested, MAX_CHANGED_FILES_CEILING))
+
+    return min(requested_limits, default=DEFAULT_MAX_CHANGED_FILES)
+
+
+def _decode_git_paths(payload: bytes) -> Iterable[str]:
+    for raw_path in payload.split(b"\0"):
+        if not raw_path:
+            continue
+        yield raw_path.decode("utf-8", errors="surrogateescape")
+
+
+def current_commit(worktree: str | Path) -> str:
+    result = _run_git(worktree, ["rev-parse", "--verify", "HEAD"])
+    if result.returncode != 0:
+        raise WorkOrderSandboxError(
+            "missing_base_commit",
+            "Autonomous execution requires a worktree with a committed HEAD",
+            worktree=str(worktree),
+        )
+    try:
+        return result.stdout.decode().strip()
+    except UnicodeDecodeError as exc:
+        raise WorkOrderSandboxError(
+            "missing_base_commit",
+            "Worktree HEAD cannot be decoded",
+            worktree=str(worktree),
+        ) from exc
+
+
+def list_changed_files(worktree: str | Path, base_commit: str | None = None) -> list[str]:
+    """Return committed, staged, unstaged, deleted, renamed, and untracked paths."""
+
+    commands: list[list[str]] = [
+        ["diff", "--name-only", "--no-renames", "-z"],
+        ["diff", "--cached", "--name-only", "--no-renames", "-z"],
+        ["ls-files", "--others", "--exclude-standard", "-z"],
+    ]
+    if base_commit:
+        commands.insert(
+            0,
+            ["diff", base_commit, "--name-only", "--no-renames", "-z"],
+        )
+    changed: set[str] = set()
+    for command in commands:
+        result = _run_git(worktree, command)
+        if result.returncode != 0:
+            raise WorkOrderSandboxError(
+                "git_status_failed",
+                "Unable to inspect worktree changes",
+                worktree=str(worktree),
+            )
+        changed.update(_decode_git_paths(result.stdout))
+    return sorted(changed)
+
+
+def _path_is_allowed(path: str, allowed_paths: tuple[str, ...]) -> bool:
+    return any(path == allowed or path.startswith(f"{allowed}/") for allowed in allowed_paths)
+
+
+def prepare_work_order_sandbox(work_order: dict[str, Any]) -> WorkOrderSandbox:
+    """Validate a clean, realpath-confined execution boundary before dispatch."""
+
+    worktree = resolve_git_worktree(work_order.get("worktree"))
+    allowed_paths = normalize_allowed_paths(work_order.get("allowed_paths"), worktree)
+    max_changed_files = max_changed_files_from_constraints(work_order.get("constraints"))
+    dirty_paths = list_changed_files(worktree)
+    if dirty_paths:
+        raise WorkOrderSandboxError(
+            "dirty_worktree",
+            "Worktree must be clean before autonomous execution",
+            worktree=str(worktree),
+            changed_files=dirty_paths,
+        )
+    base_commit = current_commit(worktree)
+    return WorkOrderSandbox(
+        worktree=str(worktree),
+        base_commit=base_commit,
+        allowed_paths=allowed_paths,
+        max_changed_files=max_changed_files,
+    )
+
+
+def assess_worktree_changes(sandbox: WorkOrderSandbox) -> dict[str, Any]:
+    """Fail closed when a worker crosses its path or change-count boundary."""
+
+    changed_files = list_changed_files(sandbox.worktree, sandbox.base_commit)
+    head_commit = current_commit(sandbox.worktree)
+    out_of_scope = [
+        path for path in changed_files if not _path_is_allowed(path, sandbox.allowed_paths)
+    ]
+    if out_of_scope:
+        return {
+            **sandbox.to_dict(),
+            "ok": False,
+            "reason": "changed_path_outside_allowlist",
+            "changed_files": changed_files,
+            "out_of_scope": out_of_scope,
+            "head_commit": head_commit,
+        }
+    if head_commit != sandbox.base_commit:
+        return {
+            **sandbox.to_dict(),
+            "ok": False,
+            "reason": "worker_mutated_git_history",
+            "changed_files": changed_files,
+            "head_commit": head_commit,
+        }
+    if len(changed_files) > sandbox.max_changed_files:
+        return {
+            **sandbox.to_dict(),
+            "ok": False,
+            "reason": "changed_file_limit_exceeded",
+            "changed_files": changed_files,
+            "changed_file_count": len(changed_files),
+            "head_commit": head_commit,
+        }
+    return {**sandbox.to_dict(), "changed_files": changed_files, "head_commit": head_commit}

--- a/scripts/autonomy/work_order_sandbox.py
+++ b/scripts/autonomy/work_order_sandbox.py
@@ -10,7 +10,10 @@ https://github.com/builderz-labs/mission-control/blob/0552b00b3b743ed12949e6deb1
 
 from __future__ import annotations
 
+import hashlib
+import os
 import re
+import stat
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -20,7 +23,27 @@ from typing import Any, Iterable
 DEFAULT_MAX_CHANGED_FILES = 6
 MAX_CHANGED_FILES_CEILING = 25
 SANDBOX_BLOCKER_CLASS = "sandbox_violation"
+MAX_GIT_METADATA_ENTRIES = 512
+MAX_GIT_METADATA_FILE_BYTES = 2 * 1024 * 1024
 _MAX_CHANGED_FILES = re.compile(r"^max_changed_files\s*=\s*(.+)$", re.IGNORECASE)
+_SENSITIVE_GIT_PATHS = (
+    "HEAD",
+    "index",
+    "config",
+    "config.worktree",
+    "hooks",
+    "info/exclude",
+    "info/attributes",
+    "objects/info/alternates",
+    "objects/info/http-alternates",
+    "MERGE_HEAD",
+    "MERGE_MSG",
+    "CHERRY_PICK_HEAD",
+    "REVERT_HEAD",
+    "rebase-apply",
+    "rebase-merge",
+    "sequencer",
+)
 
 
 class WorkOrderSandboxError(ValueError):
@@ -47,6 +70,7 @@ class WorkOrderSandbox:
 
     worktree: str
     base_commit: str
+    git_metadata_digest: str
     allowed_paths: tuple[str, ...]
     max_changed_files: int
 
@@ -55,6 +79,7 @@ class WorkOrderSandbox:
             "ok": True,
             "worktree": self.worktree,
             "base_commit": self.base_commit,
+            "git_metadata_digest": self.git_metadata_digest,
             "allowed_paths": list(self.allowed_paths),
             "max_changed_files": self.max_changed_files,
         }
@@ -66,6 +91,7 @@ def _run_git(worktree: str | Path, args: list[str]) -> subprocess.CompletedProce
         cwd=str(worktree),
         capture_output=True,
         check=False,
+        env={**os.environ, "GIT_OPTIONAL_LOCKS": "0"},
     )
 
 
@@ -220,6 +246,203 @@ def current_commit(worktree: str | Path) -> str:
         ) from exc
 
 
+def _git_path(worktree: str | Path, relative_path: str) -> Path:
+    result = _run_git(
+        worktree,
+        ["rev-parse", "--path-format=absolute", "--git-path", relative_path],
+    )
+    if result.returncode != 0:
+        raise WorkOrderSandboxError(
+            "git_metadata_unavailable",
+            "Unable to resolve repository metadata paths",
+            git_path=relative_path,
+        )
+    try:
+        return Path(result.stdout.decode().strip())
+    except UnicodeDecodeError as exc:
+        raise WorkOrderSandboxError(
+            "git_metadata_unavailable",
+            "Repository metadata path cannot be decoded",
+            git_path=relative_path,
+        ) from exc
+
+
+def _configured_hooks_path(worktree: str | Path) -> Path | None:
+    result = _run_git(worktree, ["config", "--path", "--get", "core.hooksPath"])
+    if result.returncode == 1:
+        return None
+    if result.returncode != 0:
+        raise WorkOrderSandboxError(
+            "git_metadata_unavailable", "Unable to resolve the configured Git hooks path"
+        )
+    try:
+        raw_path = result.stdout.decode().strip()
+    except UnicodeDecodeError as exc:
+        raise WorkOrderSandboxError(
+            "git_metadata_unavailable", "Configured Git hooks path cannot be decoded"
+        ) from exc
+    if not raw_path:
+        return None
+    path = Path(raw_path).expanduser()
+    return path if path.is_absolute() else Path(worktree) / path
+
+
+def _hash_metadata_path(
+    digest: Any,
+    path: Path,
+    label: str,
+    budget: dict[str, int],
+    visited: set[tuple[int, int]],
+    *,
+    follow_symlinks: bool = True,
+    recurse_directories: bool = True,
+) -> None:
+    digest.update(f"path:{label}\0".encode())
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        digest.update(b"missing\0")
+        return
+    except OSError as exc:
+        raise WorkOrderSandboxError(
+            "git_metadata_unavailable",
+            "Repository metadata cannot be inspected",
+            git_path=label,
+        ) from exc
+
+    budget["entries"] += 1
+    if budget["entries"] > MAX_GIT_METADATA_ENTRIES:
+        raise WorkOrderSandboxError(
+            "git_metadata_unbounded",
+            "Repository metadata boundary contains too many entries",
+            git_path=label,
+        )
+
+    mode = metadata.st_mode
+    digest.update(f"mode:{stat.S_IFMT(mode)}:{stat.S_IMODE(mode)}\0".encode())
+    if stat.S_ISLNK(mode):
+        try:
+            target = os.readlink(path)
+        except OSError as exc:
+            raise WorkOrderSandboxError(
+                "git_metadata_unavailable",
+                "Repository metadata symlink cannot be read",
+                git_path=label,
+            ) from exc
+        digest.update(f"link:{target}\0".encode())
+        if not follow_symlinks:
+            return
+        try:
+            resolved = path.resolve(strict=True)
+        except OSError as exc:
+            raise WorkOrderSandboxError(
+                "git_metadata_unavailable",
+                "Repository metadata symlink target cannot be resolved",
+                git_path=label,
+            ) from exc
+        _hash_metadata_path(
+            digest,
+            resolved,
+            f"{label}->target",
+            budget,
+            visited,
+            follow_symlinks=True,
+            recurse_directories=True,
+        )
+        return
+
+    inode = (metadata.st_dev, metadata.st_ino)
+    if inode in visited:
+        digest.update(b"visited\0")
+        return
+    visited.add(inode)
+
+    if stat.S_ISDIR(mode):
+        if not recurse_directories:
+            return
+        try:
+            children = sorted(path.iterdir(), key=lambda child: child.name)
+        except OSError as exc:
+            raise WorkOrderSandboxError(
+                "git_metadata_unavailable",
+                "Repository metadata directory cannot be read",
+                git_path=label,
+            ) from exc
+        for child in children:
+            _hash_metadata_path(
+                digest,
+                child,
+                f"{label}/{child.name}",
+                budget,
+                visited,
+                follow_symlinks=True,
+                recurse_directories=True,
+            )
+        return
+
+    if stat.S_ISREG(mode):
+        if metadata.st_size > MAX_GIT_METADATA_FILE_BYTES:
+            raise WorkOrderSandboxError(
+                "git_metadata_unbounded",
+                "Repository metadata file exceeds the snapshot limit",
+                git_path=label,
+                size=metadata.st_size,
+            )
+        try:
+            with path.open("rb") as source:
+                for chunk in iter(lambda: source.read(64 * 1024), b""):
+                    digest.update(chunk)
+        except OSError as exc:
+            raise WorkOrderSandboxError(
+                "git_metadata_unavailable",
+                "Repository metadata file cannot be read",
+                git_path=label,
+            ) from exc
+
+
+def repository_metadata_digest(worktree: str | Path) -> str:
+    """Fingerprint Git state that can alter status, staging, commit, or hook behavior."""
+
+    digest = hashlib.sha256()
+    budget = {"entries": 0}
+    visited: set[tuple[int, int]] = set()
+    _hash_metadata_path(
+        digest,
+        Path(worktree) / ".git",
+        "worktree/.git",
+        budget,
+        visited,
+        follow_symlinks=False,
+        recurse_directories=False,
+    )
+    for relative_path in _SENSITIVE_GIT_PATHS:
+        _hash_metadata_path(
+            digest,
+            _git_path(worktree, relative_path),
+            relative_path,
+            budget,
+            visited,
+        )
+    hooks_path = _configured_hooks_path(worktree)
+    if hooks_path is not None:
+        _hash_metadata_path(
+            digest,
+            hooks_path,
+            "core.hooksPath",
+            budget,
+            visited,
+        )
+
+    config = _run_git(worktree, ["config", "--null", "--show-origin", "--list"])
+    if config.returncode != 0:
+        raise WorkOrderSandboxError(
+            "git_metadata_unavailable", "Unable to inspect effective Git configuration"
+        )
+    digest.update(b"effective-config\0")
+    digest.update(config.stdout)
+    return digest.hexdigest()
+
+
 def list_changed_files(worktree: str | Path, base_commit: str | None = None) -> list[str]:
     """Return committed, staged, unstaged, deleted, renamed, and untracked paths."""
 
@@ -250,6 +473,23 @@ def _path_is_allowed(path: str, allowed_paths: tuple[str, ...]) -> bool:
     return any(path == allowed or path.startswith(f"{allowed}/") for allowed in allowed_paths)
 
 
+def _changed_symlink_paths(worktree: str | Path, changed_files: list[str]) -> list[str]:
+    root = Path(worktree)
+    symlink_paths: list[str] = []
+    for relative_path in changed_files:
+        candidate = root
+        for part in PurePosixPath(relative_path).parts:
+            candidate /= part
+            try:
+                if candidate.is_symlink():
+                    symlink_paths.append(relative_path)
+                    break
+            except OSError:
+                symlink_paths.append(relative_path)
+                break
+    return symlink_paths
+
+
 def prepare_work_order_sandbox(work_order: dict[str, Any]) -> WorkOrderSandbox:
     """Validate a clean, realpath-confined execution boundary before dispatch."""
 
@@ -265,9 +505,11 @@ def prepare_work_order_sandbox(work_order: dict[str, Any]) -> WorkOrderSandbox:
             changed_files=dirty_paths,
         )
     base_commit = current_commit(worktree)
+    git_metadata_digest = repository_metadata_digest(worktree)
     return WorkOrderSandbox(
         worktree=str(worktree),
         base_commit=base_commit,
+        git_metadata_digest=git_metadata_digest,
         allowed_paths=allowed_paths,
         max_changed_files=max_changed_files,
     )
@@ -276,8 +518,38 @@ def prepare_work_order_sandbox(work_order: dict[str, Any]) -> WorkOrderSandbox:
 def assess_worktree_changes(sandbox: WorkOrderSandbox) -> dict[str, Any]:
     """Fail closed when a worker crosses its path or change-count boundary."""
 
-    changed_files = list_changed_files(sandbox.worktree, sandbox.base_commit)
     head_commit = current_commit(sandbox.worktree)
+    if head_commit != sandbox.base_commit:
+        return {
+            **sandbox.to_dict(),
+            "ok": False,
+            "reason": "worker_mutated_git_history",
+            "changed_files": [],
+            "head_commit": head_commit,
+        }
+
+    git_metadata_digest = repository_metadata_digest(sandbox.worktree)
+    if git_metadata_digest != sandbox.git_metadata_digest:
+        return {
+            **sandbox.to_dict(),
+            "ok": False,
+            "reason": "repository_metadata_changed",
+            "changed_files": [],
+            "head_commit": head_commit,
+            "current_git_metadata_digest": git_metadata_digest,
+        }
+
+    changed_files = list_changed_files(sandbox.worktree, sandbox.base_commit)
+    changed_symlinks = _changed_symlink_paths(sandbox.worktree, changed_files)
+    if changed_symlinks:
+        return {
+            **sandbox.to_dict(),
+            "ok": False,
+            "reason": "changed_symlink_path",
+            "changed_files": changed_files,
+            "changed_symlinks": changed_symlinks,
+            "head_commit": head_commit,
+        }
     out_of_scope = [
         path for path in changed_files if not _path_is_allowed(path, sandbox.allowed_paths)
     ]
@@ -288,14 +560,6 @@ def assess_worktree_changes(sandbox: WorkOrderSandbox) -> dict[str, Any]:
             "reason": "changed_path_outside_allowlist",
             "changed_files": changed_files,
             "out_of_scope": out_of_scope,
-            "head_commit": head_commit,
-        }
-    if head_commit != sandbox.base_commit:
-        return {
-            **sandbox.to_dict(),
-            "ok": False,
-            "reason": "worker_mutated_git_history",
-            "changed_files": changed_files,
             "head_commit": head_commit,
         }
     if len(changed_files) > sandbox.max_changed_files:

--- a/tests/test_autonomy_work_order_sandbox.py
+++ b/tests/test_autonomy_work_order_sandbox.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AUTONOMY_DIR = ROOT / "scripts" / "autonomy"
+SANDBOX_PATH = AUTONOMY_DIR / "work_order_sandbox.py"
+
+
+def _load_sandbox_module():
+    spec = importlib.util.spec_from_file_location("work_order_sandbox", SANDBOX_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SANDBOX = _load_sandbox_module()
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+@pytest.fixture
+def clean_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "sandbox@example.com")
+    _git(repo, "config", "user.name", "Sandbox Test")
+    (repo / "docs").mkdir()
+    (repo / "docs" / "tracked.md").write_text("baseline\n", encoding="utf-8")
+    _git(repo, "add", "docs/tracked.md")
+    _git(repo, "commit", "-qm", "baseline")
+    return repo
+
+
+def _work_order(repo: Path, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "worktree": str(repo),
+        "allowed_paths": ["docs/"],
+        "constraints": ["max_changed_files=6"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_prepare_sandbox_resolves_clean_exact_git_root(clean_repo: Path) -> None:
+    sandbox = SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
+
+    assert sandbox.worktree == str(clean_repo.resolve())
+    assert sandbox.base_commit == _git(clean_repo, "rev-parse", "HEAD").stdout.strip()
+    assert sandbox.allowed_paths == ("docs",)
+    assert sandbox.max_changed_files == 6
+
+
+def test_prepare_sandbox_rejects_git_subdirectory(clean_repo: Path) -> None:
+    with pytest.raises(SANDBOX.WorkOrderSandboxError) as exc_info:
+        SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo / "docs"))
+
+    assert exc_info.value.reason == "worktree_not_root"
+
+
+@pytest.mark.parametrize(
+    "allowed_path",
+    ["../outside", "/tmp/outside", ".", ".git/config", "docs/../outside", "docs\\file"],
+)
+def test_prepare_sandbox_rejects_unsafe_allowed_paths(clean_repo: Path, allowed_path: str) -> None:
+    with pytest.raises(SANDBOX.WorkOrderSandboxError) as exc_info:
+        SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo, allowed_paths=[allowed_path]))
+
+    assert exc_info.value.reason == "invalid_allowed_path"
+
+
+def test_prepare_sandbox_rejects_allowed_path_symlink_escape(
+    clean_repo: Path, tmp_path: Path
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (clean_repo / "escape").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(SANDBOX.WorkOrderSandboxError) as exc_info:
+        SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo, allowed_paths=["escape"]))
+
+    assert exc_info.value.reason == "allowed_path_escape"
+
+
+def test_prepare_sandbox_rejects_dirty_worktree(clean_repo: Path) -> None:
+    (clean_repo / "docs" / "untracked.md").write_text("dirty\n", encoding="utf-8")
+
+    with pytest.raises(SANDBOX.WorkOrderSandboxError) as exc_info:
+        SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
+
+    assert exc_info.value.reason == "dirty_worktree"
+    assert exc_info.value.context["changed_files"] == ["docs/untracked.md"]
+
+
+def test_assessment_accepts_changes_inside_declared_paths(clean_repo: Path) -> None:
+    sandbox = SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
+    (clean_repo / "docs" / "tracked.md").write_text("updated\n", encoding="utf-8")
+
+    result = SANDBOX.assess_worktree_changes(sandbox)
+
+    assert result["ok"] is True
+    assert result["changed_files"] == ["docs/tracked.md"]
+
+
+def test_assessment_fails_closed_for_out_of_scope_changes(clean_repo: Path) -> None:
+    sandbox = SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
+    (clean_repo / "app").mkdir()
+    (clean_repo / "app" / "page.tsx").write_text("export default null\n", encoding="utf-8")
+
+    result = SANDBOX.assess_worktree_changes(sandbox)
+
+    assert result["ok"] is False
+    assert result["reason"] == "changed_path_outside_allowlist"
+    assert result["out_of_scope"] == ["app/page.tsx"]
+
+
+def test_assessment_checks_both_sides_of_cross_boundary_rename(clean_repo: Path) -> None:
+    sandbox = SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
+    (clean_repo / "app").mkdir()
+    _git(clean_repo, "mv", "docs/tracked.md", "app/tracked.md")
+
+    result = SANDBOX.assess_worktree_changes(sandbox)
+
+    assert result["ok"] is False
+    assert result["changed_files"] == ["app/tracked.md", "docs/tracked.md"]
+    assert result["out_of_scope"] == ["app/tracked.md"]
+
+
+def test_assessment_catches_out_of_scope_changes_committed_by_worker(clean_repo: Path) -> None:
+    sandbox = SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
+    (clean_repo / "app").mkdir()
+    (clean_repo / "app" / "committed.ts").write_text("export const value = 1\n", encoding="utf-8")
+    _git(clean_repo, "add", "app/committed.ts")
+    _git(clean_repo, "commit", "-qm", "worker tried to hide an out-of-scope change")
+
+    assert SANDBOX.list_changed_files(clean_repo) == []
+    result = SANDBOX.assess_worktree_changes(sandbox)
+
+    assert result["ok"] is False
+    assert result["reason"] == "changed_path_outside_allowlist"
+    assert result["out_of_scope"] == ["app/committed.ts"]
+
+
+def test_assessment_reserves_git_history_mutation_for_orchestrator(clean_repo: Path) -> None:
+    sandbox = SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
+    (clean_repo / "docs" / "tracked.md").write_text("worker commit\n", encoding="utf-8")
+    _git(clean_repo, "add", "docs/tracked.md")
+    _git(clean_repo, "commit", "-qm", "worker bypasses orchestrator")
+
+    result = SANDBOX.assess_worktree_changes(sandbox)
+
+    assert result["ok"] is False
+    assert result["reason"] == "worker_mutated_git_history"
+    assert result["changed_files"] == ["docs/tracked.md"]
+    assert result["head_commit"] != result["base_commit"]
+
+
+def test_assessment_enforces_clamped_changed_file_limit(clean_repo: Path) -> None:
+    sandbox = SANDBOX.prepare_work_order_sandbox(
+        _work_order(clean_repo, constraints=["max_changed_files=1"])
+    )
+    (clean_repo / "docs" / "one.md").write_text("one\n", encoding="utf-8")
+    (clean_repo / "docs" / "two.md").write_text("two\n", encoding="utf-8")
+
+    result = SANDBOX.assess_worktree_changes(sandbox)
+
+    assert result["ok"] is False
+    assert result["reason"] == "changed_file_limit_exceeded"
+    assert result["changed_file_count"] == 2
+    assert SANDBOX.max_changed_files_from_constraints(["max_changed_files=1000"]) == 25
+
+
+@pytest.mark.parametrize(
+    "runner_script",
+    ["run_codex_lane.py", "run_opencode_lane.py", "run_main_lane.py"],
+)
+def test_every_lane_runner_blocks_dirty_worktree_before_dispatch(
+    clean_repo: Path, tmp_path: Path, runner_script: str
+) -> None:
+    (clean_repo / "docs" / "untracked.md").write_text("dirty\n", encoding="utf-8")
+    work_order_path = tmp_path / f"{runner_script}.json"
+    work_order_path.write_text(
+        json.dumps(
+            {
+                "id": "sandbox-contract",
+                "title": "Sandbox contract",
+                "description": "Must fail before invoking a worker",
+                "lane": "main",
+                "worktree": str(clean_repo),
+                "allowed_paths": ["docs/"],
+                "constraints": ["max_changed_files=6"],
+                "verification": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(AUTONOMY_DIR / runner_script), str(work_order_path), "--execute"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["blocker_class"] == "sandbox_violation"
+    assert payload["sandbox"]["reason"] == "dirty_worktree"
+    assert payload["verification_passed"] is False
+
+
+@pytest.mark.parametrize(
+    "runner_script",
+    ["run_codex_lane.py", "run_opencode_lane.py", "run_main_lane.py"],
+)
+def test_every_lane_runner_rechecks_boundary_after_verification(
+    clean_repo: Path, tmp_path: Path, runner_script: str
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for worker_name in ("codex", "opencode"):
+        worker = fake_bin / worker_name
+        worker.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        worker.chmod(0o755)
+
+    verifier = tmp_path / "write_outside_scope.py"
+    verifier.write_text(
+        "from pathlib import Path\n"
+        "import sys\n"
+        "target = Path(sys.argv[1]) / 'app' / 'generated.ts'\n"
+        "target.parent.mkdir()\n"
+        "target.write_text('export const generated = true\\n')\n",
+        encoding="utf-8",
+    )
+    work_order_path = tmp_path / f"verify-{runner_script}.json"
+    work_order_path.write_text(
+        json.dumps(
+            {
+                "id": "sandbox-verification-contract",
+                "title": "Sandbox verification contract",
+                "description": "Verification cannot cross the work-order boundary",
+                "lane": "main",
+                "worktree": str(clean_repo),
+                "allowed_paths": ["docs/"],
+                "constraints": ["max_changed_files=6"],
+                "verification": [f"{sys.executable} {verifier} {clean_repo}"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = {**os.environ, "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}"}
+
+    result = subprocess.run(
+        [sys.executable, str(AUTONOMY_DIR / runner_script), str(work_order_path), "--execute"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["verification"][0]["exit_code"] == 0
+    assert payload["blocker_class"] == "sandbox_violation"
+    assert payload["sandbox"]["reason"] == "changed_path_outside_allowlist"
+    assert payload["sandbox"]["out_of_scope"] == ["app/generated.ts"]
+    assert payload["verification_passed"] is False

--- a/tests/test_autonomy_work_order_sandbox.py
+++ b/tests/test_autonomy_work_order_sandbox.py
@@ -136,7 +136,7 @@ def test_assessment_fails_closed_for_out_of_scope_changes(clean_repo: Path) -> N
 def test_assessment_checks_both_sides_of_cross_boundary_rename(clean_repo: Path) -> None:
     sandbox = SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
     (clean_repo / "app").mkdir()
-    _git(clean_repo, "mv", "docs/tracked.md", "app/tracked.md")
+    (clean_repo / "docs" / "tracked.md").rename(clean_repo / "app" / "tracked.md")
 
     result = SANDBOX.assess_worktree_changes(sandbox)
 
@@ -156,8 +156,8 @@ def test_assessment_catches_out_of_scope_changes_committed_by_worker(clean_repo:
     result = SANDBOX.assess_worktree_changes(sandbox)
 
     assert result["ok"] is False
-    assert result["reason"] == "changed_path_outside_allowlist"
-    assert result["out_of_scope"] == ["app/committed.ts"]
+    assert result["reason"] == "worker_mutated_git_history"
+    assert result["changed_files"] == []
 
 
 def test_assessment_reserves_git_history_mutation_for_orchestrator(clean_repo: Path) -> None:
@@ -170,8 +170,48 @@ def test_assessment_reserves_git_history_mutation_for_orchestrator(clean_repo: P
 
     assert result["ok"] is False
     assert result["reason"] == "worker_mutated_git_history"
-    assert result["changed_files"] == ["docs/tracked.md"]
+    assert result["changed_files"] == []
     assert result["head_commit"] != result["base_commit"]
+
+
+def test_assessment_rejects_git_hook_tampering(clean_repo: Path) -> None:
+    sandbox = SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
+    hook = clean_repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    hook.chmod(0o755)
+
+    result = SANDBOX.assess_worktree_changes(sandbox)
+
+    assert result["ok"] is False
+    assert result["reason"] == "repository_metadata_changed"
+    assert result["changed_files"] == []
+
+
+def test_assessment_rejects_git_config_tampering(clean_repo: Path) -> None:
+    sandbox = SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
+    _git(clean_repo, "config", "core.hooksPath", "../hooks")
+
+    result = SANDBOX.assess_worktree_changes(sandbox)
+
+    assert result["ok"] is False
+    assert result["reason"] == "repository_metadata_changed"
+    assert result["changed_files"] == []
+
+
+def test_assessment_rejects_changed_symlink_paths(clean_repo: Path, tmp_path: Path) -> None:
+    sandbox = SANDBOX.prepare_work_order_sandbox(_work_order(clean_repo))
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    escape = clean_repo / "docs" / "escape"
+    escape.symlink_to(outside, target_is_directory=True)
+    (escape / "pwned.txt").write_text("outside\n", encoding="utf-8")
+
+    result = SANDBOX.assess_worktree_changes(sandbox)
+
+    assert result["ok"] is False
+    assert result["reason"] == "changed_symlink_path"
+    assert result["changed_files"] == ["docs/escape"]
+    assert result["changed_symlinks"] == ["docs/escape"]
 
 
 def test_assessment_enforces_clamped_changed_file_limit(clean_repo: Path) -> None:

--- a/tests/test_oss_attribution_contract.py
+++ b/tests/test_oss_attribution_contract.py
@@ -43,9 +43,9 @@ def test_upstream_versions_licenses_and_refs_are_pinned() -> None:
             "b7aa0b7ad56f60428d692278a435c5e6640cec2b",
         ),
         "mission-control": (
-            "v2.1.0",
+            "v2.2.0",
             "MIT",
-            "b4ebc5418bea4fa9288a5c17fbddb9ba99740964",
+            "0552b00b3b743ed12949e6deb19597655b02bbcc",
         ),
         "orchestra-research": (
             "v1.7.2",
@@ -112,6 +112,16 @@ def test_evidence_uses_immutable_source_and_license_links() -> None:
     assert faramesh["installer_license"] == "MPL-2.0"
     assert faramesh["installer_ref"] in faramesh["installer_source_url"]
     assert faramesh["installer_ref"] in faramesh["installer_license_url"]
+
+    mission_control = projects["mission-control"]
+    assert mission_control["verified_at"] == "2026-07-22"
+    assert mission_control["comparison_baseline_version"] == "v2.1.0"
+    assert mission_control["comparison_baseline_ref"] == (
+        "b4ebc5418bea4fa9288a5c17fbddb9ba99740964"
+    )
+    assert mission_control["provenance_ref"] == ("eb7c35e950b83f73d6fd61e89f7d4b377db2ad50")
+    for source_url in mission_control["reviewed_contract_source_urls"]:
+        assert mission_control["current_ref"] in source_url
 
 
 def test_required_apache_and_mpl_license_texts_are_verbatim() -> None:
@@ -180,6 +190,26 @@ def test_direct_port_ledger_has_durable_evidence() -> None:
     assert "UI-PORT-PLAN.md" not in ledger
     assert "Record the exact upstream repo URL" not in ledger
     assert "LACP (`MIT`)" not in ledger
+
+
+def test_mission_control_refresh_preserves_history_and_pins_v220_contract() -> None:
+    current_ref = "0552b00b3b743ed12949e6deb19597655b02bbcc"
+    comparison_ref = "b4ebc5418bea4fa9288a5c17fbddb9ba99740964"
+    historical_port_ref = "eb7c35e950b83f73d6fd61e89f7d4b377db2ad50"
+    report = (ROOT / "docs/upstream-dep-report.md").read_text(encoding="utf-8")
+    credits = (ROOT / "CREDITS.md").read_text(encoding="utf-8")
+    sandbox = (ROOT / "scripts/autonomy/work_order_sandbox.py").read_text(encoding="utf-8")
+
+    for text in (report, credits):
+        assert "v2.2.0" in text
+        assert current_ref in text
+        assert comparison_ref in text
+        assert "2026-07-22" in text
+
+    assert historical_port_ref in report
+    assert current_ref in sandbox
+    assert "src/lib/task-dispatch.ts" in sandbox
+    assert "Copyright (c) 2026 Builderz Labs" in sandbox
 
 
 def test_public_legal_docs_expose_attribution_and_alignment_pages() -> None:


### PR DESCRIPTION
## Summary

Refresh the Mission Control upstream lane from the v2.1.0 comparison baseline to the verified v2.2.0 release and adapt its highest-value applicable contract: fail-closed host-worker dispatch boundaries.

- pins upstream v2.2.0 tag commit `0552b00b3b743ed12949e6deb19597655b02bbcc`
- verifies MIT, Copyright (c) 2026 Builderz Labs, at that immutable ref
- preserves the historical dashboard port provenance at upstream `eb7c35e950b83f73d6fd61e89f7d4b377db2ad50` and MUTX `972ab49b0af83d15042b2301679246103cbdbab6`
- retains v2.1.0 / `b4ebc5418bea4fa9288a5c17fbddb9ba99740964` as the explicit behavioral comparison baseline

Part of #3688.

## Contract adopted

Upstream source:

- https://github.com/builderz-labs/mission-control/blob/0552b00b3b743ed12949e6deb19597655b02bbcc/src/lib/task-dispatch.ts
- https://github.com/builderz-labs/mission-control/blob/0552b00b3b743ed12949e6deb19597655b02bbcc/src/lib/__tests__/task-dispatch-sandbox.test.ts

MUTX now enforces the equivalent repository-native boundary in every Codex, OpenCode, and main autonomy runner:

- resolve the exact Git worktree root through realpath
- reject traversal, absolute, `.git`, and symlink-escaping allowed paths
- require a clean pre-dispatch worktree
- pin pre-dispatch HEAD and detect worker-created commits
- fingerprint security-sensitive Git metadata, hooks, and effective configuration
- inspect committed, staged, unstaged, deleted, renamed, and untracked paths
- reject changed symlink paths and check both sides of renames
- clamp and enforce `max_changed_files`
- recheck the boundary after worker execution and after verification
- skip verification/publication when the boundary is violated

The broader upstream workspace database model, host-administration API, gateway registry, and filesystem API were intentionally not copied because MUTX has a different authenticated FastAPI ownership boundary. The historical briefing components only received Tailwind utility renames in v2.2.0, with no behavioral dashboard delta to port.

## Validation

- `pytest tests/test_autonomy_*.py tests/test_run_opencode_lane.py tests/test_oss_attribution_contract.py -q` — 85 passed
- `pytest tests/test_autonomy_work_order_sandbox.py tests/test_run_opencode_lane.py -q` — 29 passed
- `jest tests/unit/dashboardPanels.test.ts tests/unit/navigation.test.ts --runInBand` — 6 passed
- focused Ruff check and format check — passed
- `python3 -m compileall -q scripts/autonomy` — passed
- JSON parse of `docs/legal/oss-attribution-evidence.json` — passed
- `git diff --check` — passed
- linked-worktree metadata digest stability check — passed

Head: `46b077e0`
