### PR TITLE
fix(deps): update brace-expansion to 5.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6570,9 +6570,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- update the single hoisted `brace-expansion` lock entry from 5.0.6 to 5.0.7
- refresh only its version, registry tarball URL, and integrity hash
- keep `package.json` and the existing `^5.0.6` override unchanged

## Why

Dependabot alert #184 reports GHSA-3jxr-9vmj-r5cp / CVE-2026-13149, a denial of service in consecutive non-expanding brace groups. Version 5.0.7 contains the upstream fix and satisfies the existing override.

## Impact

This is a development-only transitive dependency update. The lockfile remains reproducible and `npm audit` no longer reports `brace-expansion`.

## Validation

- `npx --yes npm@11.12.1 ci`
- `npx --yes npm@11.12.1 ls brace-expansion --all` — every path resolves to 5.0.7
- bounded disclosed-pattern regression — passes in 158.53 ms for 2,048 consecutive non-expanding groups
- `npx --yes npm@11.12.1 run lint`
- `npx --yes npm@11.12.1 run typecheck`
- `npx --yes npm@11.12.1 run test:app` — 54 suites / 432 tests passed
- `npx --yes npm@11.12.1 run build`
- exact diff gate — one file, three insertions, three deletions; `package.json` unchanged

## Known pre-existing compatibility debt

The repository's global brace-expansion v5 override is outside the declared brace-expansion ranges used by `minimatch@3`, `@5`, and `@9`. A representative brace smoke test passes for `minimatch@10.2.4`, but the older majors fail because they expect the v1/v2 callable export. This is already true with the current v5.0.6 override; 5.0.7 preserves the v5 API. Repo lint, typecheck, unit tests, and production build all pass. The cross-major override should be cleaned up separately rather than expanding this security PR.

## Audit note

The full npm audit still reports two unrelated high findings (`next` and `sharp`); `brace-expansion` is absent after this change.