### PR TITLE
Scope brace-expansion security overrides by API line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,9 @@ jobs:
           pip install -r requirements.txt
           pip install -e ".[dev]"
 
+      - name: Validate JavaScript dependency compatibility
+        run: npm run test:dependency-compat
+
       - name: Run frontend unit tests
         run: npm run test:app
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
               - 'eslint.config.mjs'
               - 'next.config.mjs'
               - 'docs/api/openapi.json'
+              - 'scripts/check-js-dependency-compat.mjs'
               - 'scripts/verify-generated-artifacts.sh'
             scripts:
               - 'scripts/**'
@@ -183,10 +184,15 @@ jobs:
     name: Production Compose Smoke
     runs-on: ubuntu-latest
     needs:
+      - changes
       - python-validation
       - frontend-validation
     # Run on main pushes and on PRs that change scripts (scripts/**, .github/workflows/ci.yml)
-    if: github.event_name == 'push' || needs.changes.outputs.scripts == 'true'
+    if: >-
+      always() &&
+      (github.event_name == 'push' || needs.changes.outputs.scripts == 'true') &&
+      (needs.python-validation.result == 'success' || needs.python-validation.result == 'skipped') &&
+      (needs.frontend-validation.result == 'success' || needs.frontend-validation.result == 'skipped')
 
     env:
       POSTGRES_USER: mutx

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1001,6 +1000,23 @@
       },
       "engines": {
         "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@electron/universal/node_modules/minimatch": {
@@ -2446,6 +2462,23 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@jest/reporters/node_modules/glob": {
@@ -4176,6 +4209,23 @@
       "engines": {
         "node": ">=18.17.0",
         "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/minimatch": {
@@ -7301,6 +7351,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -9131,6 +9188,23 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -11002,6 +11076,23 @@
         }
       }
     },
+    "node_modules/jest-config/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/jest-config/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -11381,6 +11472,23 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/jest-runtime/node_modules/glob": {
@@ -12878,6 +12986,24 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/minimist": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "typecheck": "tsc --noEmit",
     "test": "npm run test:app",
     "test:app": "jest --runInBand tests/unit",
+    "test:dependency-compat": "node scripts/check-js-dependency-compat.mjs",
     "test:e2e:dashboard": "playwright test tests/dashboardAgents.spec.ts tests/dashboardOpenClaw.spec.ts tests/dashboardRouteMatrix.spec.ts --project=chromium --workers=1",
     "smoke:dashboard": "node scripts/dashboard-interactions-smoke.mjs",
     "test:e2e:release": "bash scripts/run-release-web-smoke.sh",
@@ -179,7 +180,9 @@
     "@babel/core": "^7.29.7",
     "@xmldom/xmldom": "^0.9.10",
     "app-builder-bin": "5.0.0-alpha.13",
-    "brace-expansion": "^5.0.6",
+    "brace-expansion@<2.0.0": "1.1.16",
+    "brace-expansion@>=2.0.0 <3.0.0": "2.1.2",
+    "brace-expansion@>=3.0.0": "5.0.7",
     "form-data": "^4.0.6",
     "gray-matter": {
       "js-yaml": "^3.15.0"

--- a/scripts/check-js-dependency-compat.mjs
+++ b/scripts/check-js-dependency-compat.mjs
@@ -1,0 +1,84 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const packageManifests = readdirSync("node_modules", {
+  encoding: "utf8",
+  recursive: true,
+})
+  .filter((entry) => entry.endsWith("package.json"))
+  .map((entry) => resolve("node_modules", entry));
+
+const readManifest = (path) => JSON.parse(readFileSync(path, "utf8"));
+const compareVersions = (left, right) => {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+
+  for (let index = 0; index < 3; index += 1) {
+    const delta = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (delta !== 0) return delta;
+  }
+
+  return 0;
+};
+
+const braceManifests = packageManifests.filter(
+  (path) => readManifest(path).name === "brace-expansion",
+);
+
+if (braceManifests.length === 0) {
+  throw new Error("No installed brace-expansion packages found");
+}
+
+for (const manifestPath of braceManifests) {
+  const { version } = readManifest(manifestPath);
+  const major = Number(version.split(".")[0]);
+  // Patched release lines for GHSA-3jxr-9vmj-r5cp.
+  const minimum = major === 1 ? "1.1.16" : major === 2 ? "2.1.2" : "5.0.7";
+
+  if (
+    !Number.isInteger(major) ||
+    major < 1 ||
+    compareVersions(version, minimum) < 0
+  ) {
+    throw new Error(`Unpatched brace-expansion ${version} at ${manifestPath}`);
+  }
+}
+
+const minimatchManifests = packageManifests.filter(
+  (path) => readManifest(path).name === "minimatch",
+);
+
+if (minimatchManifests.length === 0) {
+  throw new Error("No installed minimatch packages found");
+}
+
+for (const manifestPath of minimatchManifests) {
+  const { version } = readManifest(manifestPath);
+  const loaded = require(dirname(manifestPath));
+  const match =
+    typeof loaded === "function"
+      ? loaded
+      : (loaded.minimatch ?? loaded.default);
+
+  if (typeof match !== "function") {
+    throw new Error(`No callable minimatch export for ${version}`);
+  }
+
+  if (
+    !match("src/index.ts", "src/**/*.ts") ||
+    match("README.md", "src/**/*.ts")
+  ) {
+    throw new Error(`minimatch ${version} failed its compatibility probe`);
+  }
+}
+
+const braceVersions = [
+  ...new Set(braceManifests.map((path) => readManifest(path).version)),
+]
+  .sort(compareVersions)
+  .join(", ");
+console.log(
+  `Dependency compatibility passed: brace-expansion ${braceVersions}; ${minimatchManifests.length} minimatch installation(s) probed.`,
+);


### PR DESCRIPTION
## What changed
- replace the global brace-expansion v5 override with patched versions for the 1.x, 2.x, and 5.x API lines
- restore compatibility for minimatch 3, 5, and 9 consumers without reopening GHSA-3jxr-9vmj-r5cp
- add a CI probe that rejects unpatched brace-expansion installs and exercises every installed minimatch export

## Verification
- npm 11.12.1 clean install: 0 audit findings
- dependency compatibility: 1.1.16 / 2.1.2 / 5.0.7 across 12 minimatch installations
- 432 Jest tests
- ESLint
- TypeScript
- production Next.js build (87 routes)
- git diff --check

The prior global v5 override closed the advisory but crossed incompatible CommonJS/API lines for older minimatch majors. This keeps each consumer on its patched compatible line.